### PR TITLE
feat(search): group results into book cards with stable scrollbars

### DIFF
--- a/SeforimApp/src/commonMain/composeResources/values/strings.xml
+++ b/SeforimApp/src/commonMain/composeResources/values/strings.xml
@@ -484,6 +484,8 @@
     <string name="search_load_more">טען תוצאות נוספות</string>
     <string name="search_result_count">נמצאו %1$d/%2$d תוצאות</string>
     <string name="search_result_count_complete">נמצאו %1$d תוצאות</string>
+    <string name="search_more_in_book">עוד %1$d תוצאות בספר זה</string>
+    <string name="search_collapse">הסתר</string>
     <string name="search_stop">בטל חיפוש</string>
     <string name="search_near_selector_label">קרבה</string>
     <string name="search_extended_label">חיפוש מורחב (כל הספרים)</string>

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsContent.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsContent.kt
@@ -362,6 +362,7 @@ private fun SearchTabContent(
     val selectedTocIds by viewModel.selectedTocIdsFlow.collectAsState()
     val tocCounts by viewModel.tocCountsFlow.collectAsState()
     val tocTree by viewModel.tocTreeFlow.collectAsState()
+    val bookCounts by viewModel.bookFacetCountsFlow.collectAsState()
 
     val actions =
         remember(viewModel) {
@@ -422,6 +423,8 @@ private fun SearchTabContent(
         selectedTocIds = selectedTocIds,
         tocCounts = tocCounts,
         tocTree = tocTree,
+        bookCounts = bookCounts,
+        loadBookHits = viewModel::loadAllHitsForBook,
         actions = actions,
     )
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchResultScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchResultScreen.kt
@@ -6,18 +6,26 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
@@ -31,7 +39,6 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -52,9 +59,9 @@ import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.Enha
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.StartVerticalBar
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.asStable
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.panels.bookcontent.BookContentPanel
+import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.panels.bookcontent.views.ContentAwareScrollbarShell
 import io.github.kdroidfilter.seforimapp.features.search.domain.TocTree
 import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
-import io.github.kdroidfilter.seforimapp.logger.debugln
 import io.github.kdroidfilter.seforimlibrary.core.models.SearchResult
 import io.github.santimattius.structured.annotations.StructuredScope
 import kotlinx.collections.immutable.ImmutableList
@@ -64,6 +71,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -185,6 +193,8 @@ fun SearchResultInBookShellMvi(
     selectedTocIds: Set<Long>,
     tocCounts: Map<Long, Int>,
     tocTree: TocTree?,
+    bookCounts: Map<Long, Int>,
+    loadBookHits: suspend (Long) -> List<SearchResult>,
     actions: SearchShellActions,
 ) {
     val tabId = bookUiState.tabId
@@ -290,6 +300,8 @@ fun SearchResultInBookShellMvi(
                                     visibleResults = visibleResults,
                                     isFiltering = isFiltering,
                                     breadcrumbs = breadcrumbs,
+                                    bookCounts = bookCounts,
+                                    loadBookHits = loadBookHits,
                                     actions = actions,
                                     tabId = tabId,
                                 )
@@ -321,10 +333,41 @@ private fun SearchResultContentMvi(
     visibleResults: ImmutableList<SearchResult>,
     isFiltering: Boolean,
     breadcrumbs: ImmutableMap<Long, List<String>>,
+    bookCounts: Map<Long, Int>,
+    loadBookHits: suspend (Long) -> List<SearchResult>,
     actions: SearchShellActions,
     tabId: String,
 ) {
     val listState = rememberLazyListState()
+    // Group consecutive same-book results into Google-style cards. Cards are derived
+    // purely from the loaded list, so an already-shown card never grows beyond its cap.
+    val groups = remember(visibleResults, bookCounts) { groupResultsByBook(visibleResults, bookCounts) }
+    val lineToGroupIndex =
+        remember(groups) {
+            buildMap {
+                groups.forEachIndexed { gi, g -> g.allLineIds.forEach { put(it, gi) } }
+            }
+        }
+    // Expansion state, hoisted so it survives LazyColumn item recycling and regrouping.
+    val expandedBooks = remember { mutableStateMapOf<Long, Boolean>() }
+    val expandedHits = remember { mutableStateMapOf<Long, List<SearchResult>>() }
+    val contentScope = rememberCoroutineScope()
+    val currentLoadBookHits by rememberUpdatedState(loadBookHits)
+    val onToggleExpand: (BookGroup) -> Unit = { group ->
+        val id = group.bookId
+        if (expandedBooks[id] == true) {
+            expandedBooks[id] = false
+        } else {
+            expandedBooks[id] = true
+            val loadedCount = 1 + group.secondaries.size
+            if (group.totalCount > loadedCount && id !in expandedHits) {
+                contentScope.launch {
+                    // Always store (even an empty result) so the loading spinner resolves.
+                    expandedHits[id] = runCatching { currentLoadBookHits(id) }.getOrDefault(emptyList())
+                }
+            }
+        }
+    }
     val findQuery by AppSettings.findQueryFlow(tabId).collectAsState("")
     val showFind by AppSettings.findBarOpenFlow(tabId).collectAsState()
     val activeFindQuery = if (showFind) findQuery else ""
@@ -359,8 +402,8 @@ private fun SearchResultContentMvi(
             .distinctUntilChanged()
             .filter { !state.isLoading }
             .collect { (index, offset) ->
-                val items = state.results
-                val anchorId = items.getOrNull(index)?.lineId ?: -1L
+                // index is a group index; anchor on the group's primary line
+                val anchorId = groups.getOrNull(index)?.primary?.lineId ?: -1L
                 actions.onScroll(anchorId, 0, index, offset)
             }
     }
@@ -368,14 +411,9 @@ private fun SearchResultContentMvi(
     // Restore scroll/anchor when a new anchor timestamp is emitted.
     // We restore exactly once per timestamp to handle new searches and filter changes.
     var lastRestoredTs by remember { mutableLongStateOf(0L) }
-    LaunchedEffect(state.scrollToAnchorTimestamp, state.results) {
-        if (state.results.isNotEmpty() && lastRestoredTs != state.scrollToAnchorTimestamp) {
-            val anchorIdx =
-                if (state.anchorId > 0) {
-                    state.results.indexOfFirst { it.lineId == state.anchorId }.takeIf { it >= 0 }
-                } else {
-                    null
-                }
+    LaunchedEffect(state.scrollToAnchorTimestamp, groups) {
+        if (groups.isNotEmpty() && lastRestoredTs != state.scrollToAnchorTimestamp) {
+            val anchorIdx = if (state.anchorId > 0) lineToGroupIndex[state.anchorId] else null
             val targetIndex = anchorIdx ?: state.scrollIndex
             val targetOffset = state.scrollOffset
             if (targetIndex >= 0) {
@@ -410,10 +448,6 @@ private fun SearchResultContentMvi(
         }
     }
     var currentHitIndex by remember { mutableStateOf(-1) }
-    var currentMatchStart by remember { mutableStateOf(-1) }
-
-    fun recomputeMatches(query: String) { // removed: counter not needed
-    }
 
     fun navigateTo(
         next: Boolean,
@@ -424,7 +458,7 @@ private fun SearchResultContentMvi(
         val vis = visibleResults
         if (vis.isEmpty()) return
         val size = vis.size
-        var i = if (currentHitIndex in 0 until size) currentHitIndex else listState.firstVisibleItemIndex
+        var i = (if (currentHitIndex in 0 until size) currentHitIndex else 0).coerceIn(0, size - 1)
         val step = if (next) 1 else -1
         var guard = 0
         while (guard++ < size) {
@@ -437,8 +471,8 @@ private fun SearchResultContentMvi(
                     ?.first ?: -1
             if (start >= 0) {
                 currentHitIndex = i
-                currentMatchStart = start
-                scope.launch { listState.scrollToItem(i, 24) }
+                val groupIndex = lineToGroupIndex[vis[i].lineId] ?: 0
+                scope.launch { listState.scrollToItem(groupIndex, 24) }
                 break
             }
         }
@@ -557,47 +591,52 @@ private fun SearchResultContentMvi(
                         }
                     }
                 } else {
-                    LazyColumn(
-                        state = listState,
-                        modifier = Modifier.fillMaxSize().padding(horizontal = 32.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        // Use a composite key to ensure uniqueness across books and pages
-                        itemsIndexed(items = visibleResults, key = {
-                            index,
-                            it,
-                            ->
-                            Pair(it.bookId, Pair(it.lineId, index))
-                        }) { idx, result ->
-                            val windowInfo = LocalWindowInfo.current
-                            SearchResultItemGoogleStyle(
-                                result = result,
-                                textSize = mainTextSize,
-                                lineHeight = mainLineHeight,
-                                fontFamily = hebrewFontFamily,
-                                findQuery = activeFindQuery,
-                                currentMatchStart = if (idx == currentHitIndex) currentMatchStart else null,
-                                onClick = {
-                                    val mods = windowInfo.keyboardModifiers
-                                    val openInNewTab = !(mods.isCtrlPressed || mods.isMetaPressed)
-                                    actions.onOpenResult(result, openInNewTab)
-                                },
-                                breadcrumbs = breadcrumbs,
-                                onRequestBreadcrumb = actions.onRequestBreadcrumb,
-                                bookFontCode = bookFontCode,
-                            )
-                        }
-                        // Loading indicator at the end of the list (only for lazy loading)
-                        if (state.isLoadingMore) {
-                            item {
-                                Box(
-                                    Modifier.fillMaxWidth().padding(vertical = 16.dp),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    CircularProgressIndicator()
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier.fillMaxSize().padding(start = 32.dp, end = 24.dp),
+                            verticalArrangement = Arrangement.spacedBy(10.dp),
+                        ) {
+                            // One card per book group; primary line's id is unique per group
+                            itemsIndexed(items = groups, key = { _, g -> g.primary.lineId }) { _, group ->
+                                val windowInfo = LocalWindowInfo.current
+                                BookResultCard(
+                                    group = group,
+                                    textSize = mainTextSize,
+                                    lineHeight = mainLineHeight,
+                                    fontFamily = hebrewFontFamily,
+                                    findQuery = activeFindQuery,
+                                    bookFontCode = bookFontCode,
+                                    breadcrumbs = breadcrumbs,
+                                    onRequestBreadcrumb = actions.onRequestBreadcrumb,
+                                    onOpenResult = { result ->
+                                        val mods = windowInfo.keyboardModifiers
+                                        val openInNewTab = !(mods.isCtrlPressed || mods.isMetaPressed)
+                                        actions.onOpenResult(result, openInNewTab)
+                                    },
+                                    isExpanded = expandedBooks[group.bookId] == true,
+                                    expandedHits = expandedHits[group.bookId],
+                                    onToggleExpand = onToggleExpand,
+                                )
+                            }
+                            // Loading indicator at the end of the list (only for lazy loading)
+                            if (state.isLoadingMore) {
+                                item {
+                                    Box(
+                                        Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        CircularProgressIndicator()
+                                    }
                                 }
                             }
                         }
+                        StableListScrollbar(
+                            listState = listState,
+                            loadedCount = groups.size,
+                            totalCount = maxOf(bookCounts.size, groups.size),
+                            modifier = Modifier.align(Alignment.CenterEnd),
+                        )
                     }
                 }
 
@@ -641,137 +680,475 @@ private fun SearchResultContentMvi(
     }
 }
 
-@Composable
-private fun SearchResultItemGoogleStyle(
-    result: SearchResult,
-    textSize: Float,
-    lineHeight: Float,
-    fontFamily: FontFamily,
-    findQuery: String?,
-    onClick: () -> Unit,
-    breadcrumbs: ImmutableMap<Long, List<String>>,
-    onRequestBreadcrumb: (SearchResult) -> Unit,
-    bookFontCode: String,
-    currentMatchStart: Int? = null,
+/**
+ * A book group for the grouped (Google-style) results view: a primary hit plus the
+ * secondary hits of the same book that were loaded contiguously after it.
+ * [totalCount] is the exact facet count for the book (may exceed loaded hits).
+ */
+@Stable
+private data class BookGroup(
+    val bookId: Long,
+    val bookTitle: String,
+    val primary: SearchResult,
+    val secondaries: List<SearchResult>,
+    val totalCount: Int,
 ) {
-    // Breadcrumb pieces come from state; request on-demand via callback
-    val pieces = breadcrumbs[result.lineId]
-    val currentOnRequestBreadcrumb by rememberUpdatedState(onRequestBreadcrumb)
-    LaunchedEffect(result.lineId) { if (pieces == null) currentOnRequestBreadcrumb(result) }
+    val allLineIds: List<Long>
+        get() =
+            buildList(secondaries.size + 1) {
+                add(primary.lineId)
+                secondaries.forEach { add(it.lineId) }
+            }
+}
 
-    // Derive book title and TOC leaf for the header line
-    val bookTitle = result.bookTitle
-    val tocLeaf: String? =
-        remember(pieces, bookTitle) {
-            val list = pieces ?: emptyList()
-            val bookIndex = list.indexOfFirst { it == bookTitle }
-            if (bookIndex >= 0 && bookIndex < list.lastIndex) list.last() else null
+/**
+ * Group results into one [BookGroup] per book, in first-appearance (relevance) order.
+ * A book gets exactly one card: the first time it appears it opens a group, and the same-book
+ * hits that immediately follow become its preview secondaries. Once another book intervenes,
+ * the group is sealed — later hits of an already-seen book are dropped from the list so the
+ * same book never reappears lower down (they are still counted via facets and fetched on expand).
+ * The fold is deterministic over the prefix, so earlier cards stay put as more pages load.
+ * [bookCounts] gives the exact per-book total (from Lucene facets), coerced to the loaded count.
+ */
+private fun groupResultsByBook(
+    results: List<SearchResult>,
+    bookCounts: Map<Long, Int>,
+): List<BookGroup> {
+    if (results.isEmpty()) return emptyList()
+    val groups = ArrayList<BookGroup>()
+    val seen = HashSet<Long>()
+    var primary: SearchResult? = null
+    var secondaries: ArrayList<SearchResult>? = null
+
+    fun seal() {
+        val p = primary ?: return
+        val secs = secondaries ?: emptyList<SearchResult>()
+        val total = (bookCounts[p.bookId] ?: (1 + secs.size)).coerceAtLeast(1 + secs.size)
+        groups.add(BookGroup(p.bookId, p.bookTitle, p, secs, total))
+    }
+
+    for (r in results) {
+        when {
+            // Continuation of the book currently being built → keep as a preview secondary.
+            primary != null && r.bookId == primary.bookId -> secondaries!!.add(r)
+            // A book already shown above → skip so it never appears as a second card.
+            r.bookId in seen -> Unit
+            // A new book → seal the current group and open one for this book.
+            else -> {
+                seal()
+                seen.add(r.bookId)
+                primary = r
+                secondaries = ArrayList()
+            }
         }
+    }
+    seal()
+    return groups
+}
 
-    // Full path string for the footer line
-    val sep = stringResource(Res.string.breadcrumb_separator)
-    val fullPath: String? = if (pieces.isNullOrEmpty()) null else pieces.joinToString(sep)
+// "Gilt" — the matched search term glows gold like a gilded letter (Torah-ornament palette).
+// Two tones so it reads on both light paper and the dark study surface.
+private val GiltLight = Color(0xFF9C6B08)
+private val GiltDark = Color(0xFFE8B53C)
 
-    // Build annotated snippet with bold segments coming from HTML (<b> ... )
-    // On macOS, some Hebrew fonts in our catalog don't include bold faces.
-    // Apply a subtle boldScale to keep emphasis visible on those fonts.
+@Composable
+private fun giltColor(): Color = if (JewelTheme.isDark) GiltDark else GiltLight
+
+/** Build the highlighted snippet, shared by primary and secondary rows. */
+@Composable
+private fun rememberSnippetDisplay(
+    snippet: String,
+    textSize: Float,
+    findQuery: String?,
+    bookFontCode: String,
+): AnnotatedString {
+    // On macOS, some Hebrew fonts lack bold faces; scale slightly to keep emphasis visible.
     val boldScaleForPlatform =
         remember(bookFontCode) {
             val lacksBold = bookFontCode in setOf("notoserifhebrew", "notorashihebrew", "frankruhllibre")
             if (PlatformInfo.isMacOS && lacksBold) 1.08f else 1.0f
         }
-    val boldColor = JewelTheme.globalColors.outlines.focused
+    val boldColor = giltColor()
     val footnoteMarkerColor = JewelTheme.globalColors.outlines.focused
-    val annotated: AnnotatedString =
-        remember(result.snippet, textSize, boldScaleForPlatform, boldColor, footnoteMarkerColor) {
-            // Log the snippet with bold tags for debugging
-            debugln { "[SearchResult] Book: ${result.bookTitle}, LineId: ${result.lineId}" }
-            debugln { "[SearchResult] Snippet with bold tags: ${result.snippet}" }
-            debugln { "[SearchResult] ---" }
-            // Keep keyword emphasis without oversized glyphs (slight scale on mac for non-bold fonts)
+    val annotated =
+        remember(snippet, textSize, boldScaleForPlatform, boldColor, footnoteMarkerColor) {
             buildAnnotatedFromHtml(
-                result.snippet,
+                snippet,
                 textSize,
                 boldScale = boldScaleForPlatform,
                 boldColor = boldColor,
                 footnoteMarkerColor = footnoteMarkerColor,
             )
         }
-    // Softer overlays for better legibility
     val baseHl =
         JewelTheme.globalColors.outlines.focused
             .copy(alpha = 0.12f)
     val currentHl =
         JewelTheme.globalColors.outlines.focused
             .copy(alpha = 0.28f)
-    val display =
-        remember(annotated, findQuery, currentMatchStart, baseHl, currentHl) {
-            highlightAnnotatedWithCurrent(
-                annotated = annotated,
-                query = findQuery,
-                currentStart = currentMatchStart?.takeIf { it >= 0 },
-                currentLength = findQuery?.length,
-                baseColor = baseHl,
-                currentColor = currentHl,
-            )
+    return remember(annotated, findQuery, baseHl, currentHl) {
+        highlightAnnotatedWithCurrent(
+            annotated = annotated,
+            query = findQuery,
+            currentStart = null,
+            currentLength = findQuery?.length,
+            baseColor = baseHl,
+            currentColor = currentHl,
+        )
+    }
+}
+
+/** Last breadcrumb piece (the TOC leaf) for a result, or null if not resolvable/cached. */
+private fun tocLeafOf(
+    pieces: List<String>?,
+    bookTitle: String,
+): String? {
+    val list = pieces ?: return null
+    val bookIndex = list.indexOfFirst { it == bookTitle }
+    return if (bookIndex >= 0 && bookIndex < list.lastIndex) list.last() else null
+}
+
+/**
+ * Google-style card: a book header with its exact result count, the primary hit shown
+ * prominently, a few secondary hits indented, and an inline expander for the rest.
+ */
+@Composable
+private fun BookResultCard(
+    group: BookGroup,
+    textSize: Float,
+    lineHeight: Float,
+    fontFamily: FontFamily,
+    findQuery: String?,
+    bookFontCode: String,
+    breadcrumbs: ImmutableMap<Long, List<String>>,
+    onRequestBreadcrumb: (SearchResult) -> Unit,
+    onOpenResult: (SearchResult) -> Unit,
+    isExpanded: Boolean,
+    expandedHits: List<SearchResult>?,
+    onToggleExpand: (BookGroup) -> Unit,
+) {
+    val collapsedCap = 3
+    val loadedCount = 1 + group.secondaries.size
+    val needsFetch = group.totalCount > loadedCount
+    val isLoadingExpand = isExpanded && needsFetch && expandedHits == null
+
+    // Hits to render: full set when expanded+fetched, all loaded when expanded, capped otherwise.
+    val effectiveHits: List<SearchResult> =
+        when {
+            isExpanded && !expandedHits.isNullOrEmpty() -> expandedHits
+            isExpanded ->
+                buildList {
+                    add(group.primary)
+                    addAll(group.secondaries)
+                }
+            else ->
+                buildList {
+                    add(group.primary)
+                    addAll(group.secondaries.take(collapsedCap))
+                }
+        }
+    val primary = effectiveHits.first()
+    val secondaries = effectiveHits.drop(1)
+    val remaining = (group.totalCount - effectiveHits.size).coerceAtLeast(0)
+    val showExpander = isExpanded || remaining > 0
+
+    val accent = JewelTheme.globalColors.outlines.focused
+    val cardShape = RoundedCornerShape(14.dp)
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .shadow(elevation = 2.dp, shape = cardShape)
+                .clip(cardShape)
+                .background(JewelTheme.globalColors.panelBackground)
+                .border(1.dp, JewelTheme.globalColors.borders.normal, cardShape),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 14.dp)) {
+            // Header: book title (sans, bold) + filled count chip
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = group.bookTitle,
+                    color = JewelTheme.globalColors.text.normal,
+                    fontSize = (textSize * 1.15f).sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .pointerHoverIcon(PointerIcon.Hand)
+                            .clickable { onOpenResult(group.primary) },
+                )
+                if (group.totalCount > 1) {
+                    Spacer(Modifier.width(10.dp))
+                    Box(
+                        modifier =
+                            Modifier
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(accent)
+                                .padding(horizontal = 9.dp, vertical = 4.dp),
+                    ) {
+                        Text(
+                            text = group.totalCount.toString(),
+                            color = Color.White,
+                            fontSize = (textSize * 0.8f).sp,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            // Primary hit: serif snippet (gilt term) with its location on the side,
+            // consistent with the secondaries below so the snippets read as one list.
+            val primaryPieces = breadcrumbs[primary.lineId]
+            val currentOnRequestBreadcrumb by rememberUpdatedState(onRequestBreadcrumb)
+            LaunchedEffect(primary.lineId) { if (primaryPieces == null) currentOnRequestBreadcrumb(primary) }
+            val primaryLeaf = remember(primaryPieces, primary.bookTitle) { tocLeafOf(primaryPieces, primary.bookTitle) }
+            val primaryDisplay = rememberSnippetDisplay(primary.snippet, textSize, findQuery, bookFontCode)
+            Row(
+                verticalAlignment = Alignment.Top,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(6.dp))
+                        .clickable { onOpenResult(primary) }
+                        .pointerHoverIcon(PointerIcon.Hand)
+                        .padding(vertical = 5.dp),
+            ) {
+                // Reference column (leading): the location, aligned like a concordance index.
+                Text(
+                    text = primaryLeaf.orEmpty(),
+                    color = accent,
+                    fontSize = (textSize * 0.78f).sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    modifier = Modifier.widthIn(min = (textSize * 4.4f).dp).padding(top = (textSize * 0.22f).dp),
+                )
+                Spacer(Modifier.width(14.dp))
+                Text(
+                    text = primaryDisplay,
+                    color = JewelTheme.globalColors.text.normal,
+                    fontFamily = fontFamily,
+                    lineHeight = (textSize * lineHeight).sp,
+                    fontSize = textSize.sp,
+                    textAlign = TextAlign.Justify,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            // Secondary hits: a thin divider tops every row (the first one also separates them
+            // from the primary). Each row is a fixed two-line height, so rows are uniform.
+            if (secondaries.isNotEmpty()) {
+                val dividerColor =
+                    JewelTheme.globalColors.borders.normal
+                        .copy(alpha = 0.7f)
+                val secRow: @Composable (SearchResult) -> Unit = { sec ->
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Box(Modifier.fillMaxWidth().height(1.dp).background(dividerColor))
+                        SecondaryResultRow(
+                            result = sec,
+                            textSize = textSize,
+                            lineHeight = lineHeight,
+                            fontFamily = fontFamily,
+                            findQuery = findQuery,
+                            bookFontCode = bookFontCode,
+                            pieces = breadcrumbs[sec.lineId],
+                            onRequestBreadcrumb = onRequestBreadcrumb,
+                            onClick = { onOpenResult(sec) },
+                        )
+                    }
+                }
+                Spacer(Modifier.height(4.dp))
+                if (isExpanded) {
+                    // A non-lazy scrolling Column so the height ADAPTS to the content (a
+                    // LazyColumn with fillMaxSize would always take the max). It grows with the
+                    // results, caps at ~4 rows, then scrolls. The expand already loads every hit,
+                    // so a plain Column is fine and its ScrollState gives an exact, stable thumb.
+                    val secScroll = rememberScrollState()
+                    val showBar = secScroll.maxValue > 0
+                    val maxViewportDp = (textSize * lineHeight * 2f + 31f) * 4f
+                    Box(modifier = Modifier.fillMaxWidth().heightIn(max = maxViewportDp.dp)) {
+                        Column(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .verticalScroll(secScroll)
+                                    .padding(end = if (showBar) 12.dp else 0.dp),
+                        ) {
+                            secondaries.forEach { sec -> secRow(sec) }
+                        }
+                        if (showBar) {
+                            VerticalScrollbar(
+                                modifier = Modifier.align(Alignment.CenterEnd),
+                                adapter = rememberScrollbarAdapter(secScroll),
+                            )
+                        }
+                    }
+                } else {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        secondaries.forEach { sec -> secRow(sec) }
+                    }
+                }
+            }
+
+            // Inline expander
+            if (showExpander) {
+                Spacer(Modifier.height(4.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier =
+                        Modifier
+                            .clip(RoundedCornerShape(6.dp))
+                            .pointerHoverIcon(PointerIcon.Hand)
+                            .clickable { onToggleExpand(group) }
+                            .padding(vertical = 4.dp, horizontal = 6.dp),
+                ) {
+                    if (isLoadingExpand) {
+                        CircularProgressIndicator(modifier = Modifier.size(12.dp))
+                        Spacer(Modifier.width(6.dp))
+                    }
+                    Text(
+                        text =
+                            if (isExpanded) {
+                                stringResource(Res.string.search_collapse)
+                            } else {
+                                stringResource(Res.string.search_more_in_book, remaining)
+                            },
+                        color = accent,
+                        fontSize = (textSize * 0.85f).sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Icon(
+                        key = if (isExpanded) AllIconsKeys.General.ChevronUp else AllIconsKeys.General.ChevronDown,
+                        contentDescription = stringResource(Res.string.chevron_icon_description),
+                        modifier = Modifier.padding(start = 2.dp),
+                    )
+                }
+            }
         }
 
-    // Visual layout inspired by Google results, styled with Jewel
-    Column(
+        // Book "binding": a bold accent strip on the start (right, in RTL) edge.
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.CenterStart)
+                    .fillMaxHeight()
+                    .width(4.dp)
+                    .background(accent),
+        )
+    }
+}
+
+/**
+ * Stable scrollbar reused by the results list and the expanded-secondaries list — wraps the
+ * book pane's [ContentAwareScrollbarShell]. The thumb is sized against [totalCount] (the facet
+ * book count for the paged results list; the item count for a fully-loaded expand list) using a
+ * latched average item height captured on the first laid-out frame, so the thumb keeps a stable
+ * size and does NOT shrink as more items load. [loadedCount] bounds drag targets to what is
+ * currently in the list; position tracks the live scroll offset.
+ */
+@Composable
+private fun StableListScrollbar(
+    listState: LazyListState,
+    loadedCount: Int,
+    totalCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    if (loadedCount <= 0 || totalCount <= 0) return
+    // Capture the average card height once it is known; keep it fixed so the thumb size is
+    // stable (re-captured only when the total changes, i.e. a new search).
+    var avgItemPx by remember(totalCount) { mutableFloatStateOf(0f) }
+    LaunchedEffect(totalCount, listState) {
+        snapshotFlow {
+            val visible = listState.layoutInfo.visibleItemsInfo
+            if (visible.isEmpty()) 0f else visible.sumOf { it.size }.toFloat() / visible.size
+        }.first { it > 0f }.let { avgItemPx = it }
+    }
+    if (avgItemPx <= 0f) return
+
+    val geom by remember(listState, totalCount, avgItemPx) {
+        derivedStateOf {
+            val info = listState.layoutInfo
+            val viewport = (info.viewportEndOffset - info.viewportStartOffset).toFloat()
+            val total = avgItemPx * totalCount
+            val thumb = (viewport / total).coerceIn(0f, 1f)
+            val first = info.visibleItemsInfo.firstOrNull()
+            val firstIdx = first?.index ?: 0
+            val innerFraction = if (first != null && first.size > 0) (-first.offset.toFloat() / first.size).coerceIn(0f, 1f) else 0f
+            val maxScroll = (total - viewport).coerceAtLeast(1f)
+            val position = (((firstIdx + innerFraction) * avgItemPx) / maxScroll).coerceIn(0f, 1f)
+            thumb to position
+        }
+    }
+    val (thumbSize, position) = geom
+    if (thumbSize >= 1f) return // everything fits — no scrollbar
+
+    ContentAwareScrollbarShell(
+        listState = listState,
+        position = position,
+        thumbSize = thumbSize,
+        visualsLabel = "search_results_scrollbar",
+        onApplyTarget = { ratio, _ ->
+            // Jump within the loaded range; scrolling near the end triggers the existing
+            // lazy-load, so the thumb can be dragged further as more pages arrive.
+            val target = (ratio * (totalCount - 1)).toInt().coerceIn(0, loadedCount - 1)
+            listState.requestScrollToItem(target)
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun SecondaryResultRow(
+    result: SearchResult,
+    textSize: Float,
+    lineHeight: Float,
+    fontFamily: FontFamily,
+    findQuery: String?,
+    bookFontCode: String,
+    pieces: List<String>?,
+    onRequestBreadcrumb: (SearchResult) -> Unit,
+    onClick: () -> Unit,
+) {
+    val currentOnRequestBreadcrumb by rememberUpdatedState(onRequestBreadcrumb)
+    LaunchedEffect(result.lineId) { if (pieces == null) currentOnRequestBreadcrumb(result) }
+    val tocLeaf = remember(pieces, result.bookTitle) { tocLeafOf(pieces, result.bookTitle) }
+    val display = rememberSnippetDisplay(result.snippet, textSize, findQuery, bookFontCode)
+    Row(
         modifier =
             Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(6.dp))
                 .clickable(onClick = onClick)
-                .padding(vertical = 10.dp),
+                .pointerHoverIcon(PointerIcon.Hand)
+                .padding(top = 9.dp, bottom = 9.dp),
+        verticalAlignment = Alignment.Top,
     ) {
-        // Top: small book title – toc leaf
-        Row(
-            modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
-        ) {
-            val header =
-                if (tocLeaf.isNullOrBlank()) {
-                    bookTitle
-                } else {
-                    buildString {
-                        append(bookTitle)
-                        append(stringResource(Res.string.breadcrumb_separator))
-                        append(tocLeaf)
-                    }
-                }
-            Text(
-                text = header,
-                color = JewelTheme.globalColors.text.selected,
-                fontSize = (textSize * 1.1f).sp,
-                fontFamily = fontFamily,
-                fontWeight = FontWeight.Medium,
-                textDecoration = TextDecoration.Underline,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-        Spacer(Modifier.height(2.dp))
-
-        // Middle: the snippet text with bold keywords
+        // Reference column (leading), aligned with the primary's.
+        Text(
+            text = tocLeaf.orEmpty(),
+            color = JewelTheme.globalColors.text.disabledSelected,
+            fontSize = (textSize * 0.72f).sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            modifier = Modifier.widthIn(min = (textSize * 4.4f).dp).padding(top = (textSize * 0.18f).dp),
+        )
+        Spacer(Modifier.width(14.dp))
         Text(
             text = display,
             color = JewelTheme.globalColors.text.normal,
             fontFamily = fontFamily,
             lineHeight = (textSize * lineHeight).sp,
-            fontSize = textSize.sp,
-            textAlign = TextAlign.Justify,
+            fontSize = (textSize * 0.92f).sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
         )
-
-        // Bottom: smaller full path of the book
-        if (!fullPath.isNullOrBlank()) {
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = fullPath,
-                color = JewelTheme.globalColors.text.disabledSelected,
-                fontFamily = fontFamily,
-                fontSize = (textSize * 0.8f).sp,
-                maxLines = 1,
-            )
-        }
     }
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchResultViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchResultViewModel.kt
@@ -449,6 +449,13 @@ class SearchResultViewModel(
     private val _searchTree = MutableStateFlow<ImmutableList<SearchTreeCategory>>(persistentListOf())
     val searchTreeFlow: StateFlow<ImmutableList<SearchTreeCategory>> = _searchTree.asStateFlow()
 
+    // Exact per-book hit counts from Lucene facets, used by the grouped result cards
+    // to show "(N results)" without loading every page.
+    val bookFacetCountsFlow: StateFlow<Map<Long, Int>> =
+        _categoryAgg
+            .map { it.bookCounts }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
+
     init {
         // Compute search tree when visible and results change; emits into _searchTree
         // Skip if facets have been computed (tree is built from facets directly)
@@ -1080,6 +1087,38 @@ class SearchResultViewModel(
                     )
             } catch (_: Exception) {
                 _uiState.value = _uiState.value.copy(isLoadingMore = false)
+            }
+        }
+    }
+
+    /**
+     * Load ALL hits for [bookId] under the current query/scope. Used to expand a grouped
+     * result card inline. Opens a dedicated, short-lived session restricted to the book.
+     * ponytail: restricts by bookId + baseBookOnly only; active sidebar TOC/category client
+     * filters aren't re-applied here — consistent with the facet counts shown on the card.
+     */
+    suspend fun loadAllHitsForBook(bookId: Long): List<SearchResult> {
+        val q = currentSearchQuery.takeIf { it.isNotBlank() } ?: _uiState.value.query.trim()
+        if (q.isBlank()) return emptyList()
+        val baseBookOnly = !_uiState.value.globalExtended
+        return withContext(Dispatchers.Default) {
+            val session =
+                lucene.openSession(
+                    query = q,
+                    near = DEFAULT_NEAR,
+                    bookIds = listOf(bookId),
+                    baseBookOnly = baseBookOnly,
+                ) ?: return@withContext emptyList()
+            try {
+                val all = ArrayList<LineHit>()
+                while (true) {
+                    val page = session.nextPage(LAZY_PAGE_SIZE) ?: break
+                    all += page.hits
+                    if (page.isLastPage) break
+                }
+                hitsToResults(all, q)
+            } finally {
+                runCatching { session.close() }
             }
         }
     }


### PR DESCRIPTION
## What

Redesign the search results screen: results are grouped by book into cards (one card per book), for a clearer, more scannable layout.

## Changes
- **Grouping** — results are deduplicated into one card per book, in relevance order; a book never reappears lower in the list.
- **Card layout** — book title + exact result count (from Lucene facets), the top hit shown prominently, locations in a leading reference column, matched terms highlighted in gold.
- **Inline expand** — "more results in this book" expands into a fixed-height, scrollable list (bounded so a book with many hits never blows up the card); the full hit set is loaded on demand.
- **Scrollbars** — the expanded list and the main results list both reuse the book pane's `ContentAwareScrollbarShell`, so the thumb is themed and stable. The main list thumb is sized from the total book count (facets), so it no longer shrinks as more pages stream in while scrolling.

## Notes
- ViewModel adds `bookFacetCountsFlow` and `loadAllHitsForBook(bookId)`.
- New strings: `search_more_in_book`, `search_collapse`.
- ktlint + detekt pass.
