### PR TITLE
feat(search): wire single fused dense+lexical index

### DIFF
--- a/SeforimApp/src/graalvm/reachability-metadata.json
+++ b/SeforimApp/src/graalvm/reachability-metadata.json
@@ -281,6 +281,82 @@
                     ]
                 }
             ]
+        },
+        {
+            "type": "ai.djl.huggingface.tokenizers.jni.CharSpan",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        "int",
+                        "int"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "ai.djl.huggingface.tokenizers.jni.CharSpan[]"
+        },
+        {
+            "type": "ai.onnxruntime.OnnxTensor",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        "long",
+                        "long",
+                        "ai.onnxruntime.TensorInfo"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "ai.onnxruntime.TensorInfo",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        "long[]",
+                        "java.lang.String[]",
+                        "int"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.render.TaoSyntheticKeyKt$SyntheticAwtKeyEventSource$1"
+        },
+        {
+            "type": "float[][]"
+        },
+        {
+            "type": "java.io.FileNotFoundException",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        "java.lang.String"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "org.apache.lucene.codecs.KnnVectorsFormat"
+        },
+        {
+            "type": "org.apache.lucene.codecs.hnsw.FlatVectorsFormat"
+        },
+        {
+            "type": "org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat"
+        },
+        {
+            "type": "org.apache.lucene.internal.hppc.FloatArrayList"
+        },
+        {
+            "type": "org.apache.lucene.util.SparseFixedBitSet"
         }
     ],
     "foreign": {
@@ -305,6 +381,26 @@
         ]
     },
     "resources": [
-        
+        {
+            "glob": "ai/onnxruntime/native/linux-x64/libonnxruntime.so"
+        },
+        {
+            "glob": "ai/onnxruntime/native/linux-x64/libonnxruntime4j_jni.so"
+        },
+        {
+            "glob": "ai/onnxruntime/native/linux-x64/libonnxruntime_providers_shared.so"
+        },
+        {
+            "glob": "libcudart.so"
+        },
+        {
+            "glob": "linux-x86-64/libcudart.so"
+        },
+        {
+            "glob": "native/lib/tokenizers.properties"
+        },
+        {
+            "glob": "tokenizers-engine.properties"
+        }
     ]
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/di/modules/AppCoreBindings.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/di/modules/AppCoreBindings.kt
@@ -30,6 +30,8 @@ import io.github.kdroidfilter.seforimapp.framework.search.RepositorySnippetSourc
 import io.github.kdroidfilter.seforimapp.framework.session.TabPersistedStateStore
 import io.github.kdroidfilter.seforimapp.framework.update.AppUpdateService
 import io.github.kdroidfilter.seforimlibrary.dao.repository.SeforimRepository
+import io.github.kdroidfilter.seforimlibrary.search.HybridSearchEngine
+import io.github.kdroidfilter.seforimlibrary.search.LineHit
 import io.github.kdroidfilter.seforimlibrary.search.LuceneSearchEngine
 import io.github.kdroidfilter.seforimlibrary.search.SearchEngine
 import java.nio.file.Paths
@@ -98,6 +100,16 @@ object AppCoreBindings {
         return SeforimRepository(dbPath, driver)
     }
 
+    /**
+     * The app's search engine. Returns a HYBRID engine (lexical BM25 + MagicDictionary
+     * FUSED with dense semantic search via the v5 embedding model, RRF) over a SINGLE
+     * Lucene index that holds both the text fields and the dense vectors.
+     * It implements [SearchEngine], so the rest of the app uses it transparently.
+     *
+     * Degrades gracefully to pure lexical if the embedding model is absent (the app
+     * works with or without the model from the SeforimEmbedding project). The dense
+     * path uses the model bundled next to the DB (or `-DseforimEmbedModelDir`).
+     */
     @Provides
     @SingleIn(AppScope::class)
     fun provideSearchEngine(repository: SeforimRepository): SearchEngine {
@@ -105,7 +117,29 @@ object AppCoreBindings {
         val indexPath = Paths.get(if (dbPath.endsWith(".db")) "$dbPath.lucene" else "$dbPath.luceneindex")
         val dictionaryPath = indexPath.resolveSibling("lexical.db")
         val snippetProvider = RepositorySnippetSourceProvider(repository)
-        return LuceneSearchEngine(indexPath, snippetProvider, dictionaryPath = dictionaryPath)
+        val lexical = LuceneSearchEngine(indexPath, snippetProvider, dictionaryPath = dictionaryPath)
+        // Single fused index: dense vectors live in the SAME Lucene index as the text
+        // (seforim.db.lucene), so the dense searcher opens that same directory.
+        // The embedding model is bundled next to the DB (extracted from the .tar.zst),
+        // so the embedder looks in the database directory.
+        val modelDir = Paths.get(dbPath).parent
+        return HybridSearchEngine.create(lexical, indexDir = indexPath, modelDir = modelDir) { lineId, _, query ->
+            val line = repository.getLine(lineId)
+            if (line == null) {
+                null
+            } else {
+                val title = repository.getBook(line.bookId)?.title ?: ""
+                LineHit(
+                    bookId = line.bookId,
+                    bookTitle = title,
+                    lineId = lineId,
+                    lineIndex = line.lineIndex,
+                    snippet = lexical.buildSnippet(line.content, query, 5),
+                    score = 0f,
+                    rawText = line.content,
+                )
+            }
+        }
     }
 
     @Provides


### PR DESCRIPTION
## Summary
- `AppCoreBindings` now opens a **single fused Lucene index** (`seforim.db.lucene`) holding both text fields and dense `KnnFloatVectorField` vectors — used for lexical *and* semantic search. The separate vector-index path (`vectorIndexDir`/`seforimVectorIndex`/`vector-lucene`) is gone.
- GraalVM: added native-image **reachability metadata** for the ONNX Runtime + DJL HuggingFace tokenizer JNI classes used by the dense embedder.
- Bumped **SeforimLibrary** submodule to `900771c` (v5 dense search, single-index refactor merged via #85).

## Test plan
- [x] App builds and runs (`./gradlew :SeforimApp:run`)
- [x] Search returns results (lexical) and dense path activates on first query with the normal spinner
- [x] Native image build picks up the ONNX/DJL JNI metadata