### PR TITLE
feat(search): wire embedding-only semantic highlight (incl. native image)

### DIFF
--- a/SeforimApp/src/graalvm/reachability-metadata.json
+++ b/SeforimApp/src/graalvm/reachability-metadata.json
@@ -353,10 +353,68 @@
             "type": "org.apache.lucene.codecs.lucene99.Lucene99FlatVectorsFormat"
         },
         {
+            "type": "org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "org.apache.lucene.codecs.lucene99.Lucene99ScalarQuantizedVectorsFormat",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "org.apache.lucene.codecs.lucene102.Lucene102HnswBinaryQuantizedVectorsFormat",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "org.apache.lucene.codecs.lucene102.Lucene102BinaryQuantizedVectorsFormat",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+
+                    ]
+                }
+            ]
+        },
+        {
             "type": "org.apache.lucene.internal.hppc.FloatArrayList"
         },
         {
             "type": "org.apache.lucene.util.SparseFixedBitSet"
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.render.TaoSyntheticMouseWheelEvent$source$1"
         }
     ],
     "foreign": {
@@ -397,10 +455,13 @@
             "glob": "linux-x86-64/libcudart.so"
         },
         {
-            "glob": "native/lib/tokenizers.properties"
+            "glob": "tokenizers-engine.properties"
         },
         {
-            "glob": "tokenizers-engine.properties"
+            "glob": "META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat"
+        },
+        {
+            "glob": "META-INF/services/org.apache.lucene.codecs.hnsw.FlatVectorsFormat"
         }
     ]
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
@@ -644,19 +644,29 @@ fun BookContentView(
         }
     }
 
-    // Smart mode: get highlight terms from search engine with dictionary expansion
+    // Smart find = embedding-based (vs simple mode which matches literal words): for the typed
+    // query we fetch the lines of THIS book closest in meaning (dense KNN over the index) and the
+    // passage to highlight in each. Per-line highlight reads from this map; navigation jumps
+    // between its lines. Computed off-main; empty when dense search is unavailable.
     val appGraph = LocalAppGraph.current
-    val smartHighlightTerms by remember(smartModeEnabled, findState) {
-        derivedStateOf {
-            if (smartModeEnabled) {
-                val query = findState.text.toString()
-                if (query.length >= 2) {
-                    appGraph.searchEngine.buildHighlightTerms(query)
-                } else {
-                    emptyList()
+    val semanticFindIds by androidx.compose.runtime.produceState<Set<Long>>(
+        emptySet(),
+        smartModeEnabled,
+        persistedFindQuery,
+        bookId,
+    ) {
+        val query = persistedFindQuery
+        value = if (!smartModeEnabled || query.length < 2) {
+            emptySet()
+        } else {
+            withContext(kotlinx.coroutines.Dispatchers.Default) {
+                try {
+                    appGraph.searchEngine.semanticFind(query, bookId, SMART_FIND_LIMIT).toSet()
+                } catch (c: kotlinx.coroutines.CancellationException) {
+                    throw c // composition left / keys changed — not a real failure
+                } catch (_: Throwable) {
+                    emptySet()
                 }
-            } else {
-                emptyList()
             }
         }
     }
@@ -767,11 +777,18 @@ fun BookContentView(
             while (guard++ < size) {
                 i = (i + step + size) % size
                 val line = snapshot[i] ?: continue
-                val text =
-                    plainTextCache.getOrPut(line.id) {
-                        buildAnnotatedFromHtml(line.content, textSize).text
+                // Smart mode jumps between semantically-matched lines; simple mode finds the
+                // literal query. In smart mode the highlight span is the line's whole passage.
+                val start =
+                    if (smartModeEnabled) {
+                        if (line.id in semanticFindIds) 0 else -1
+                    } else {
+                        val text =
+                            plainTextCache.getOrPut(line.id) {
+                                buildAnnotatedFromHtml(line.content, textSize).text
+                            }
+                        findAllMatchesOriginal(text, query).firstOrNull()?.first ?: -1
                     }
-                val start = findAllMatchesOriginal(text, query).firstOrNull()?.first ?: -1
                 if (start >= 0) {
                     kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
                         currentHitLineIndex = i
@@ -934,6 +951,26 @@ fun BookContentView(
                     val line = lazyPagingItems[index]
 
                     if (line != null) {
+                        // Smart find: this line's passage closest in meaning to the query, computed
+                        // on the DISPLAYED text (same HTML pipeline as rendering) so the span is
+                        // always found back — short passages included. Falls back to the whole line.
+                        val isSmartMatch = showFind && smartModeEnabled && line.id in semanticFindIds
+                        val smartPassage by androidx.compose.runtime.produceState<String?>(
+                            null,
+                            line.id,
+                            persistedFindQuery,
+                            isSmartMatch,
+                        ) {
+                            value = if (!isSmartMatch || persistedFindQuery.length < 2) {
+                                null
+                            } else {
+                                withContext(kotlinx.coroutines.Dispatchers.Default) {
+                                    val plain = buildAnnotatedFromHtml(line.content, textSize).text
+                                    runCatching { appGraph.searchEngine.semanticSpan(persistedFindQuery, plain) }
+                                        .getOrNull() ?: plain.trim().ifBlank { null }
+                                }
+                            }
+                        }
                         val altHeadings = altHeadingsByLineId[line.id]
                         val isCurrentSelected = line.id in selectedLineIds
                         val useThickBar = shouldUseThickBar(line.id, primarySelectedLineId, isTocEntrySelection)
@@ -1028,8 +1065,15 @@ fun BookContentView(
                                         lineHeight = lineHeight,
                                         boldScale = boldScaleForPlatform,
                                         highlightQuery =
-                                            findState.text.toString().takeIf { showFind && !smartModeEnabled },
-                                        highlightTerms = smartHighlightTerms.takeIf { showFind && smartModeEnabled },
+                                            when {
+                                                !showFind -> null
+                                                // Smart mode: highlight this line's own semantic
+                                                // passage (one contiguous span) if it's a match;
+                                                // simple mode: the literal query.
+                                                smartModeEnabled -> smartPassage
+                                                else -> findState.text.toString()
+                                            },
+                                        highlightTerms = null,
                                         currentMatchStart =
                                             if (showFind && currentMatchLineId == line.id) currentMatchStart else null,
                                         annotatedCache = stableAnnotatedCache,
@@ -1143,24 +1187,27 @@ fun BookContentView(
             // Compute total matches across currently loaded snapshot (approximate)
             val queryText = findState.text.toString()
             val snapshotItems = lazyPagingItems.itemSnapshotList.items
-            val matchCount by produceState(0, queryText, snapshotItems) {
+            // Smart mode counts semantically-matched lines; simple mode counts literal matches
+            // across the loaded snapshot (approximate).
+            val matchCount by produceState(0, queryText, snapshotItems, smartModeEnabled, semanticFindIds) {
                 value =
-                    if (queryText.length < 2) {
-                        0
-                    } else {
-                        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
-                            var total = 0
-                            for (ln in snapshotItems) {
-                                val text =
-                                    try {
-                                        buildAnnotatedFromHtml(ln.content, textSize).text
-                                    } catch (_: Throwable) {
-                                        ln.content
-                                    }
-                                total += findAllMatchesOriginal(text, queryText).size
+                    when {
+                        queryText.length < 2 -> 0
+                        smartModeEnabled -> semanticFindIds.size
+                        else ->
+                            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
+                                var total = 0
+                                for (ln in snapshotItems) {
+                                    val text =
+                                        try {
+                                            buildAnnotatedFromHtml(ln.content, textSize).text
+                                        } catch (_: Throwable) {
+                                            ln.content
+                                        }
+                                    total += findAllMatchesOriginal(text, queryText).size
+                                }
+                                total
                             }
-                            total
-                        }
                     }
             }
             Row(
@@ -1214,6 +1261,9 @@ internal val LineItemVerticalPaddingPerSide = 8.dp
 // since scrolling down is the dominant direction in a reading app.
 private const val HTML_PREFETCH_AHEAD = 16
 private const val HTML_PREFETCH_BEHIND = 8
+
+// Smart (embedding) find: max semantically-closest lines fetched per query for the current book.
+private const val SMART_FIND_LIMIT = 60
 
 // Data class for anchor information
 private data class AnchorData(


### PR DESCRIPTION
## Summary
Consumes SeforimLibrary #88 and wires the embedding-only semantic highlight into the app, working in both JVM and the GraalVM native image.

- **BookContentView**: smart find/highlight is now embedding-based. Per matched line, the highlighted passage is the one closest in meaning to the query (computed on the *displayed* text so the span is always found back); the book-scoped semantic match set drives navigation and the match count. The dictionary term bag is gone.
- **main.kt**: warm the dense backend (embedding model + vector index) once at app scope so it's ready before the first search and isn't cancelled by tab/composition churn.
- **GraalVM reachability**: register the Lucene `KnnVectorsFormat` SPI implementations + service resources and the ONNX Runtime native libs, so dense search/highlight work in the native binary.
- **Bump SeforimLibrary** submodule to `466287e` (semantic highlight + the `NIOFSDirectory` native-image fix).

## Test plan
- [x] App compiles (JVM)
- [x] JVM: semantic search + highlight work
- [x] GraalVM native image: dense backend ready, smart find returns hits, passages highlighted (verified via runGraalvmNative)