### PR TITLE
feat(tabs): open-in-new-window action in the tab context menu

### DIFF
--- a/SeforimApp/src/commonMain/composeResources/values/strings.xml
+++ b/SeforimApp/src/commonMain/composeResources/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="desktop_rename">שנה שם</string>
     <string name="desktop_delete">מחק</string>
     <string name="desktop_open_in_new_window">פתח בחלון חדש</string>
+    <string name="tab_open_in_new_window">פתח בחלון חדש</string>
     <string name="menu_new_window">חלון חדש</string>
 
     <!-- Tabs View -->

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
@@ -109,6 +109,8 @@ private data class TabEntry(
     val onCloseRight: () -> Unit,
     // null when the destination has nothing shareable (e.g. Home, or a book still loading)
     val onCopyLink: (() -> Unit)?,
+    // null when the tab is the window's only one (the window itself already is that tab)
+    val onDetach: (() -> Unit)?,
 )
 
 private val TabTooltipWidthThreshold = 140.dp
@@ -133,6 +135,8 @@ private fun DefaultTabShowcase(
 ) {
     val layoutDirection = LocalLayoutDirection.current
     val isRtl = layoutDirection == LayoutDirection.Rtl
+    val desktopManager = LocalAppGraph.current.desktopManager
+    val windowId = LocalOpenWindow.current.id
 
     // Track for auto-scrolling (no-op in shrink-to-fit mode)
     var previousTabCount by remember { mutableStateOf(state.tabs.size) }
@@ -207,6 +211,12 @@ private fun DefaultTabShowcase(
                             onCloseLeft = { onEvents(TabsEvents.CloseRight(actualIndex)) },
                             onCloseRight = { onEvents(TabsEvents.CloseLeft(actualIndex)) },
                             onCopyLink = tabItem.destination.toShareLink()?.let { link -> { copyToClipboard(link) } },
+                            onDetach =
+                                if (state.tabs.size > 1) {
+                                    { desktopManager.detachTabToNewWindow(tabItem.destination.tabId, windowId) }
+                                } else {
+                                    null
+                                },
                         )
                     }.toImmutableList()
             } else {
@@ -270,6 +280,12 @@ private fun DefaultTabShowcase(
                             onCloseLeft = { onEvents(TabsEvents.CloseLeft(index)) },
                             onCloseRight = { onEvents(TabsEvents.CloseRight(index)) },
                             onCopyLink = tabItem.destination.toShareLink()?.let { link -> { copyToClipboard(link) } },
+                            onDetach =
+                                if (state.tabs.size > 1) {
+                                    { desktopManager.detachTabToNewWindow(tabItem.destination.tabId, windowId) }
+                                } else {
+                                    null
+                                },
                         )
                     }.toImmutableList()
             }
@@ -521,6 +537,7 @@ private fun RtlAwareTabStripContent(
                                             onCloseLeft = tabEntry.onCloseLeft,
                                             onCloseRight = tabEntry.onCloseRight,
                                             onCopyLink = tabEntry.onCopyLink,
+                                            onDetach = tabEntry.onDetach,
                                             animateWidth = !isNew,
                                             enterFromSmall = isNew,
                                             enterDurationMs = enterDurationMs,
@@ -627,6 +644,7 @@ private fun RtlAwareTab(
     onCloseRight: () -> Unit,
     modifier: Modifier = Modifier,
     onCopyLink: (() -> Unit)? = null,
+    onDetach: (() -> Unit)? = null,
     animateWidth: Boolean = true,
     enterFromSmall: Boolean = false,
     enterDurationMs: Int = 200,
@@ -890,12 +908,23 @@ private fun RtlAwareTab(
             val closeLeftLabel = stringResource(Res.string.close_tabs_left)
             val closeRightLabel = stringResource(Res.string.close_tabs_right)
             val copyLinkLabel = stringResource(Res.string.copy_tab_link)
+            val detachLabel = stringResource(Res.string.tab_open_in_new_window)
 
             TabContextMenu(
                 anchorOffset = anchorOffset,
                 contextClickOffset = contextClickOffset,
                 onDismissRequest = { contextMenuOpen = false },
             ) {
+                if (onDetach != null) {
+                    tabContextMenuItem(
+                        label = detachLabel,
+                        icon = AllIconsKeys.Actions.OpenNewTab,
+                        onClick = {
+                            contextMenuOpen = false
+                            onDetach()
+                        },
+                    )
+                }
                 if (onCopyLink != null) {
                     tabContextMenuItem(
                         label = copyLinkLabel,
@@ -1113,6 +1142,30 @@ private class StripGeometry(
         if (tabWidth <= 0f) return tabCount
         val visualIndex = ((screenX - bounds.left) / tabWidth).roundToInt().coerceIn(0, tabCount)
         return if (isRtl) tabCount - visualIndex else visualIndex
+    }
+}
+
+private fun MenuScope.tabContextMenuItem(
+    label: String,
+    icon: org.jetbrains.jewel.ui.icon.IconKey,
+    onClick: () -> Unit,
+) {
+    selectableItem(
+        selected = false,
+        onClick = onClick,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                key = icon,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = JewelTheme.globalColors.text.normal,
+            )
+            Text(label)
+        }
     }
 }
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/desktop/DesktopManager.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/desktop/DesktopManager.kt
@@ -271,16 +271,22 @@ class DesktopManager(
         val item = from.tabsViewModel.takeTab(tabId) ?: return null
         val desktopId = from.desktopId.value
         // Chrome-like: the detached window floats noticeably smaller than the (often maximized)
-        // source window, under the cursor — it must never inherit a maximized footprint.
+        // source window — it must never inherit a maximized footprint. With pointer coordinates
+        // (drag & drop) it lands under the cursor; without (context-menu action) it cascades
+        // from the source window.
         val sourceGeometry = from.windowState.toSavedGeometry()
         val geometry =
-            SavedGeometry(
-                x = screenX ?: SavedGeometry.UNSPECIFIED,
-                y = screenY ?: SavedGeometry.UNSPECIFIED,
-                width = (sourceGeometry.width * 3 / 4).coerceIn(640, 1200),
-                height = (sourceGeometry.height * 3 / 4).coerceIn(480, 840),
-                placement = "Floating",
-            )
+            if (screenX != null && screenY != null) {
+                SavedGeometry(
+                    x = screenX,
+                    y = screenY,
+                    width = (sourceGeometry.width * 3 / 4).coerceIn(640, 1200),
+                    height = (sourceGeometry.height * 3 / 4).coerceIn(480, 840),
+                    placement = "Floating",
+                )
+            } else {
+                cascadedFloatingGeometry(null)
+            }
         val snapshot =
             WindowSnapshot(
                 destinations = listOf(item.destination),


### PR DESCRIPTION
## What

Right-clicking a tab now offers **«פתח בחלון חדש»** as the first context-menu entry — shown only when the window has more than one tab (detaching a window's only tab is meaningless: the window already is that tab).

## How

- Reuses the drag & drop detach path (`DesktopManager.detachTabToNewWindow`): same-desktop invariant (no desktop is ever created implicitly), floating window at 3/4 of the source size.
- Context-menu invocations carry no pointer position, so the new window now **cascades from the source window** instead of centering — consistent with «open desktop in new window».
- New `tabContextMenuItem` overload accepting a Jewel `IconKey` (uses `Actions.OpenNewTab`, consistent with the desktop switcher action).

## Validation

Exercised in the running app (macOS/Tao): entry present and working on multi-tab windows, absent on single-tab windows; new window cascaded, same desktop. ktlint + detekt green.