### PR TITLE
feat(tabs): closing a window's last tab closes the window, Chrome-style

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/desktop/DesktopManager.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/desktop/DesktopManager.kt
@@ -75,6 +75,12 @@ class DesktopManager(
     /** Snapshots of desktops that are not currently open in any window. */
     private val dormantSnapshots = mutableMapOf<String, DesktopTabsSnapshot>()
 
+    /**
+     * App-level quit path (persist session, apply pending updates, exit). Wired by main.kt;
+     * invoked when the last tab of the last window is closed (Chrome-like).
+     */
+    var onQuitRequest: (() -> Unit)? = null
+
     // ---- Lookups ----
 
     fun window(windowId: String): OpenWindow? = _windows.value.find { it.id == windowId }
@@ -485,13 +491,26 @@ class DesktopManager(
                 skipAnimation = true,
             )
         }
-        return OpenWindow(
-            id = UUID.randomUUID().toString(),
-            desktopId = desktopId,
-            tabsViewModel = tabsViewModel,
-            searchHomeViewModel = searchHomeViewModelFactory(),
-            windowState = snapshot?.geometry.toWindowState(),
-        )
+        val w =
+            OpenWindow(
+                id = UUID.randomUUID().toString(),
+                desktopId = desktopId,
+                tabsViewModel = tabsViewModel,
+                searchHomeViewModel = searchHomeViewModelFactory(),
+                windowState = snapshot?.geometry.toWindowState(),
+            )
+        // Chrome-like: closing a window's last tab closes the window; closing the last window
+        // quits the app. The tab is already removed, so the desktop snapshot / persisted
+        // session no longer contains it.
+        tabsViewModel.onLastTabClosed = { removed ->
+            tabPersistedStateStore.remove(removed.destination.tabId)
+            if (_windows.value.size > 1) {
+                closeWindow(w.id)
+            } else {
+                onQuitRequest?.invoke() ?: freshHomeInto(w)
+            }
+        }
+        return w
     }
 
     private fun spawnWindow(

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
@@ -294,6 +294,8 @@ fun main(args: Array<String>) {
                         appGraph.appUpdateService.installPendingOnClose()
                         exitApplication()
                     }
+                    // Chrome-like: closing the last tab of the last window quits the app
+                    SideEffect { desktopManager.onQuitRequest = onQuit }
 
                     // App-level launcher integrations follow the focused window's tabs. key() forces
                     // their internal effects (dock/jumplist listeners) to re-register on the new

--- a/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsViewModel.kt
+++ b/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsViewModel.kt
@@ -33,6 +33,13 @@ class TabsViewModel(
 ) : ViewModel() {
     private var _nextTabId = 2
 
+    /**
+     * Chrome-like last-tab behavior: when set, closing the window's last tab removes it and
+     * delegates here (typically: close the window, or quit when it's the last one) instead of
+     * the legacy fallback of replacing the tab with a fresh Home.
+     */
+    var onLastTabClosed: ((TabItem) -> Unit)? = null
+
     /** When true, the next tab state change should not animate new tabs. Reset by the view after consuming. */
     private val _skipNextAnimation = MutableStateFlow(false)
     val skipNextAnimation: StateFlow<Boolean> = _skipNextAnimation.asStateFlow()
@@ -98,10 +105,17 @@ class TabsViewModel(
         if (index < 0 || index >= currentTabs.size) return
 
         if (currentTabs.size == 1) {
-            replaceCurrentTabWithNewTabId(
-                TabsDestination.BookContent(bookId = -1, tabId = UUID.randomUUID().toString()),
-            )
-            _state.update { it.copy(selectedTabIndex = 0) }
+            val handler = onLastTabClosed
+            if (handler != null) {
+                val removed = currentTabs[0]
+                _state.value = TabsState(tabs = emptyList(), selectedTabIndex = 0)
+                handler(removed)
+            } else {
+                replaceCurrentTabWithNewTabId(
+                    TabsDestination.BookContent(bookId = -1, tabId = UUID.randomUUID().toString()),
+                )
+                _state.update { it.copy(selectedTabIndex = 0) }
+            }
             return
         }
 


### PR DESCRIPTION
## What

Closing the last tab of a window no longer resets it to a fresh Home page:

- the tab is removed, then **the window closes** — its desktop goes dormant **empty**, so reopening the desktop doesn't resurrect the closed tab;
- when it was the **last window**, the app **quits** through the regular path (session save, pending silent update, exit) — exactly like Chrome.

Every close path funnels through the same choke point (close button, middle-click, Cmd/Ctrl+W, macOS menu).

## How

`TabsViewModel` stays window-agnostic: a new `onLastTabClosed` hook delegates the decision (legacy fresh-Home fallback when unset). `DesktopManager` wires it per window — close the window when others remain, invoke the app-level quit (injected from main.kt) otherwise.

## Notes

«Close all tabs» deliberately keeps the fresh-Home reset: Chrome has no such item, and mirroring window-close would make it redundant with the window's close button.

## Validation

Exercised in the running app (macOS/Tao): last tab of a secondary window → window closes, desktop dormant empty; last tab of the last window → clean quit with session saved and restored on next boot. ktlint + detekt green.