### PR TITLE
feat(favorites): Chrome-style bookmarks with folders

### DIFF
--- a/SeforimApp/src/commonMain/composeResources/values/strings.xml
+++ b/SeforimApp/src/commonMain/composeResources/values/strings.xml
@@ -91,6 +91,20 @@
     <string name="history_yesterday">אתמול</string>
     <string name="history_empty">ההיסטוריה ריקה</string>
     <string name="menu_recently_visited">ביקורים אחרונים</string>
+    <string name="favorites_title">מועדפים</string>
+    <string name="favorites_empty">אין מועדפים</string>
+    <string name="favorites_show_all">הצג את כל המועדפים</string>
+    <string name="favorites_add">הוסף למועדפים</string>
+    <string name="favorites_edit">עריכת מועדף</string>
+    <string name="favorites_new_folder">תיקייה חדשה</string>
+    <string name="favorites_folder_name_placeholder">שם התיקייה</string>
+    <string name="favorites_no_folder">ללא תיקייה</string>
+    <string name="favorites_search_placeholder">חפש במועדפים...</string>
+    <string name="favorites_create_folder">צור</string>
+    <string name="history_clear_confirm_title">ניקוי היסטוריה</string>
+    <string name="history_clear_confirm_message">האם אתה בטוח שברצונך למחוק את כל ההיסטוריה? פעולה זו אינה ניתנת לביטול.</string>
+    <string name="history_clear_confirm_yes">כן, נקה</string>
+    <string name="breadcrumb_copy_link">העתק קישור</string>
     <string name="menu_new_window">חלון חדש</string>
 
     <!-- Tabs View -->

--- a/SeforimApp/src/commonMain/sqldelight/io/github/kdroidfilter/seforimapp/db/Favorites.sq
+++ b/SeforimApp/src/commonMain/sqldelight/io/github/kdroidfilter/seforimapp/db/Favorites.sq
@@ -1,0 +1,59 @@
+-- Chrome-like bookmarks: one row per favorited target ("book:<id>" / "book:<id>:<tocEntryId>"),
+-- optionally grouped into user-created folders.
+CREATE TABLE IF NOT EXISTS favorite_folder (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    createdAt INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS favorite (
+    key TEXT NOT NULL PRIMARY KEY,
+    bookId INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    folderId INTEGER,
+    createdAt INTEGER NOT NULL,
+    tocEntryId INTEGER,
+    lineId INTEGER
+);
+
+upsertFavorite:
+INSERT INTO favorite(key, bookId, title, folderId, createdAt, tocEntryId, lineId)
+VALUES (:key, :bookId, :title, :folderId, :createdAt, :tocEntryId, :lineId)
+ON CONFLICT(key) DO UPDATE SET
+    title = excluded.title,
+    lineId = excluded.lineId;
+
+selectAllFavorites:
+SELECT * FROM favorite ORDER BY createdAt DESC;
+
+searchFavoritesByTitle:
+SELECT * FROM favorite
+WHERE title LIKE '%' || :query || '%' ESCAPE '\'
+ORDER BY createdAt DESC;
+
+countFavorite:
+SELECT COUNT(*) FROM favorite WHERE key = :key;
+
+selectFavoriteByKey:
+SELECT * FROM favorite WHERE key = :key;
+
+setFavoriteFolder:
+UPDATE favorite SET folderId = :folderId WHERE key = :key;
+
+deleteFavoriteByKey:
+DELETE FROM favorite WHERE key = :key;
+
+insertFolder:
+INSERT INTO favorite_folder(name, createdAt) VALUES (:name, :createdAt);
+
+lastInsertedFolderId:
+SELECT last_insert_rowid();
+
+selectFolders:
+SELECT * FROM favorite_folder ORDER BY createdAt ASC;
+
+deleteFolder:
+DELETE FROM favorite_folder WHERE id = :id;
+
+clearFolderFromFavorites:
+UPDATE favorite SET folderId = NULL WHERE folderId = :folderId;

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/deeplink/ZayitDeepLink.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/deeplink/ZayitDeepLink.kt
@@ -46,6 +46,7 @@ fun TabsDestination.toShareLink(): String? =
         is TabsDestination.Search -> searchShareLink(searchQuery)
         is TabsDestination.Home -> null
         is TabsDestination.History -> null
+        is TabsDestination.Favorites -> null
     }
 
 /**

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/favorites/FavoritesStore.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/favorites/FavoritesStore.kt
@@ -1,0 +1,152 @@
+package io.github.kdroidfilter.seforimapp.core.favorites
+
+import androidx.compose.runtime.Stable
+import io.github.kdroidfilter.seforimapp.db.Favorite
+import io.github.kdroidfilter.seforimapp.db.UserSettingsDb
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
+
+/** One favorited book position, optionally filed into a user folder (Chrome-like bookmark). */
+@Stable
+data class FavoriteEntry(
+    val key: String,
+    val bookId: Long,
+    val title: String,
+    val folderId: Long?,
+    val createdAt: Long,
+    val tocEntryId: Long? = null,
+    val lineId: Long? = null,
+)
+
+@Stable
+data class FavoriteFolder(
+    val id: Long,
+    val name: String,
+)
+
+/**
+ * Persistent favorites (the Chrome bookmarks equivalent): book positions the user starred,
+ * deduplicated by target key and optionally grouped into flat user-created folders.
+ *
+ * Reads are on-demand SQL queries; [revision] bumps on every write so UI can re-run its
+ * current query reactively.
+ */
+class FavoritesStore(
+    database: UserSettingsDb,
+) {
+    private val queries = database.favoritesQueries
+
+    private val _revision = MutableStateFlow(0L)
+    val revision: StateFlow<Long> = _revision.asStateFlow()
+
+    /** Same key scheme as the visit history so a position stars consistently. */
+    fun keyFor(
+        bookId: Long,
+        tocEntryId: Long?,
+    ): String = if (tocEntryId != null) "book:$bookId:$tocEntryId" else "book:$bookId"
+
+    suspend fun add(
+        bookId: Long,
+        title: String,
+        timestamp: Long,
+        tocEntryId: Long? = null,
+        lineId: Long? = null,
+        folderId: Long? = null,
+    ): Unit =
+        withContext(Dispatchers.IO) {
+            if (title.isBlank()) return@withContext
+            queries.upsertFavorite(
+                key = keyFor(bookId, tocEntryId),
+                bookId = bookId,
+                title = title,
+                folderId = folderId,
+                createdAt = timestamp,
+                tocEntryId = tocEntryId,
+                lineId = lineId,
+            )
+            _revision.update { it + 1 }
+        }
+
+    suspend fun remove(key: String): Unit =
+        withContext(Dispatchers.IO) {
+            queries.deleteFavoriteByKey(key)
+            _revision.update { it + 1 }
+        }
+
+    suspend fun isFavorite(key: String): Boolean =
+        withContext(Dispatchers.IO) {
+            queries.countFavorite(key).executeAsOne() > 0
+        }
+
+    suspend fun get(key: String): FavoriteEntry? =
+        withContext(Dispatchers.IO) {
+            queries.selectFavoriteByKey(key).executeAsOneOrNull()?.toEntry()
+        }
+
+    suspend fun setFolder(
+        key: String,
+        folderId: Long?,
+    ): Unit =
+        withContext(Dispatchers.IO) {
+            queries.setFavoriteFolder(folderId = folderId, key = key)
+            _revision.update { it + 1 }
+        }
+
+    /** Creates a folder and returns its id. */
+    suspend fun createFolder(
+        name: String,
+        timestamp: Long,
+    ): Long =
+        withContext(Dispatchers.IO) {
+            queries.insertFolder(name = name.trim(), createdAt = timestamp)
+            val id = queries.lastInsertedFolderId().executeAsOne()
+            _revision.update { it + 1 }
+            id
+        }
+
+    /** Deletes a folder; its favorites move back to the root. */
+    suspend fun deleteFolder(id: Long): Unit =
+        withContext(Dispatchers.IO) {
+            queries.clearFolderFromFavorites(id)
+            queries.deleteFolder(id)
+            _revision.update { it + 1 }
+        }
+
+    suspend fun folders(): List<FavoriteFolder> =
+        withContext(Dispatchers.IO) {
+            queries.selectFolders().executeAsList().map { FavoriteFolder(id = it.id, name = it.name) }
+        }
+
+    /** All favorites, or those whose title matches [query] when non-blank. */
+    suspend fun query(query: String = ""): List<FavoriteEntry> =
+        withContext(Dispatchers.IO) {
+            val rows =
+                if (query.isBlank()) {
+                    queries.selectAllFavorites().executeAsList()
+                } else {
+                    val escaped =
+                        query
+                            .trim()
+                            .replace("\\", "\\\\")
+                            .replace("%", "\\%")
+                            .replace("_", "\\_")
+                    queries.searchFavoritesByTitle(escaped).executeAsList()
+                }
+            rows.map { it.toEntry() }
+        }
+
+    private fun Favorite.toEntry(): FavoriteEntry =
+        FavoriteEntry(
+            key = key,
+            bookId = bookId,
+            title = title,
+            folderId = folderId,
+            createdAt = createdAt,
+            tocEntryId = tocEntryId,
+            lineId = lineId,
+        )
+}

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/AppNativeMenuBar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/AppNativeMenuBar.kt
@@ -17,6 +17,8 @@ import io.github.kdroidfilter.seforim.tabs.TabsDestination
 import io.github.kdroidfilter.seforim.tabs.TabsEvents
 import io.github.kdroidfilter.seforim.tabs.TabsViewModel
 import io.github.kdroidfilter.seforimapp.core.MainAppState
+import io.github.kdroidfilter.seforimapp.core.favorites.FavoriteEntry
+import io.github.kdroidfilter.seforimapp.core.favorites.FavoriteFolder
 import io.github.kdroidfilter.seforimapp.core.history.VisitEntry
 import io.github.kdroidfilter.seforimapp.core.history.VisitKind
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.AccentColor
@@ -55,6 +57,16 @@ fun AppNativeMenuBar(
         recentVisits = historyStore.query("", RECENT_VISITS_IN_MENU)
     }
 
+    // Chrome-like Favorites menu data: all favorites + folders, refreshed on every write
+    val favoritesStore = LocalAppGraph.current.favoritesStore
+    val favoritesRevision by favoritesStore.revision.collectAsState()
+    var favoriteEntries by remember { mutableStateOf<List<FavoriteEntry>>(emptyList()) }
+    var favoriteFolders by remember { mutableStateOf<List<FavoriteFolder>>(emptyList()) }
+    LaunchedEffect(favoritesRevision) {
+        favoriteEntries = favoritesStore.query()
+        favoriteFolders = favoritesStore.folders()
+    }
+
     fun openFullHistory() {
         val tabs = tabsViewModel.state.value.tabs
         val existing = tabs.indexOfFirst { it.destination is TabsDestination.History }
@@ -63,6 +75,22 @@ fun AppNativeMenuBar(
         } else {
             tabsViewModel.openTab(TabsDestination.History(tabId = UUID.randomUUID().toString()))
         }
+    }
+
+    fun openFavoritesTab() {
+        val tabs = tabsViewModel.state.value.tabs
+        val existing = tabs.indexOfFirst { it.destination is TabsDestination.Favorites }
+        if (existing >= 0) {
+            tabsViewModel.onEvent(TabsEvents.OnSelect(existing))
+        } else {
+            tabsViewModel.openTab(TabsDestination.Favorites(tabId = UUID.randomUUID().toString()))
+        }
+    }
+
+    fun openFavorite(entry: FavoriteEntry) {
+        tabsViewModel.openTab(
+            TabsDestination.BookContent(bookId = entry.bookId, tabId = UUID.randomUUID().toString(), lineId = entry.lineId),
+        )
     }
 
     fun openVisit(entry: VisitEntry) {
@@ -121,6 +149,8 @@ fun AppNativeMenuBar(
     val menuSearchPlaceholder = stringResource(Res.string.tab_search_placeholder)
     val menuShowFullHistory = stringResource(Res.string.tab_search_show_all_history)
     val menuRecentlyVisited = stringResource(Res.string.menu_recently_visited)
+    val menuFavorites = stringResource(Res.string.favorites_title)
+    val menuShowAllFavorites = stringResource(Res.string.favorites_show_all)
     val menuWindow = stringResource(Res.string.menu_window)
     val menuHelp = stringResource(Res.string.menu_help)
 
@@ -313,6 +343,46 @@ fun AppNativeMenuBar(
                             ),
                     ) {
                         openVisit(entry)
+                    }
+                }
+            }
+        }
+
+        // Favorites menu (Chrome bookmarks-like): native search field, full favorites page,
+        // then root favorites and folders as submenus
+        Menu(menuFavorites) {
+            SearchField(placeholder = menuSearchPlaceholder)
+            Item(
+                text = menuShowAllFavorites,
+                shortcut = NativeKeyShortcut("b", option = true),
+                icon = NsMenuItemImage.SystemSymbol("star"),
+            ) {
+                openFavoritesTab()
+            }
+            if (favoriteEntries.isNotEmpty()) {
+                Separator()
+                favoriteEntries.filter { it.folderId == null }.forEach { entry ->
+                    Item(
+                        text = entry.title.take(MENU_TITLE_MAX_LENGTH),
+                        icon = NsMenuItemImage.SystemSymbol("book.closed"),
+                    ) {
+                        openFavorite(entry)
+                    }
+                }
+                favoriteFolders.forEach { folder ->
+                    val folderEntries = favoriteEntries.filter { it.folderId == folder.id }
+                    Menu(
+                        text = folder.name.take(MENU_TITLE_MAX_LENGTH),
+                        icon = NsMenuItemImage.SystemSymbol("folder"),
+                    ) {
+                        folderEntries.forEach { entry ->
+                            Item(
+                                text = entry.title.take(MENU_TITLE_MAX_LENGTH),
+                                icon = NsMenuItemImage.SystemSymbol("book.closed"),
+                            ) {
+                                openFavorite(entry)
+                            }
+                        }
                     }
                 }
             }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/ListPageComponents.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/ListPageComponents.kt
@@ -1,0 +1,627 @@
+package io.github.kdroidfilter.seforimapp.core.presentation.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.PopupPositionProvider
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.DefaultButton
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.IconButton
+import org.jetbrains.jewel.ui.component.OutlinedButton
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.icon.IconKey
+import org.jetbrains.jewel.ui.icons.AllIconsKeys
+import seforimapp.seforimapp.generated.resources.Res
+import seforimapp.seforimapp.generated.resources.settings_cancel
+
+/**
+ * Shared visual primitives for list-style tab pages (history, favorites, etc.).
+ * These components follow the Jewel/Chrome settings-page aesthetic: cards, hover
+ * highlights, icon buttons, and a centered content column.
+ */
+
+@Composable
+fun ListPageContainer(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.TopCenter) {
+        Column(
+            modifier =
+                Modifier
+                    .widthIn(max = 720.dp)
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+fun PageHeader(
+    title: String,
+    actions: @Composable () -> Unit = {},
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = title,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = JewelTheme.globalColors.text.normal,
+            modifier = Modifier.weight(1f),
+        )
+        actions()
+    }
+}
+
+@Composable
+fun CardSurface(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(10.dp))
+                .border(1.dp, JewelTheme.globalColors.borders.normal, RoundedCornerShape(10.dp))
+                .background(JewelTheme.globalColors.panelBackground)
+                .padding(8.dp),
+    ) {
+        content()
+    }
+}
+
+@Composable
+fun PageSearchField(
+    query: String,
+    placeholder: StringResource,
+    onQueryChange: (String) -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(34.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .border(1.dp, JewelTheme.globalColors.borders.normal, RoundedCornerShape(8.dp))
+                .background(JewelTheme.globalColors.panelBackground)
+                .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Icon(
+            key = AllIconsKeys.Actions.Find,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = JewelTheme.globalColors.text.info,
+        )
+        BasicTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            singleLine = true,
+            textStyle = TextStyle(fontSize = 14.sp, color = JewelTheme.globalColors.text.normal),
+            cursorBrush = SolidColor(JewelTheme.globalColors.outlines.focused),
+            modifier = Modifier.weight(1f),
+            decorationBox = { innerTextField ->
+                Box {
+                    if (query.isEmpty()) {
+                        Text(
+                            text = stringResource(placeholder),
+                            fontSize = 14.sp,
+                            color = JewelTheme.globalColors.text.info,
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+        )
+        if (query.isNotBlank()) {
+            IconButton(
+                onClick = { onQueryChange("") },
+                modifier = Modifier.size(20.dp),
+            ) {
+                Icon(
+                    key = AllIconsKeys.Actions.Close,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                    tint = JewelTheme.globalColors.text.info,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SectionHeader(
+    title: String,
+    count: Int? = null,
+    expanded: Boolean = true,
+    onToggleExpand: (() -> Unit)? = null,
+    onDelete: (() -> Unit)? = null,
+    leadingIconKey: IconKey? = null,
+    leadingIconVector: ImageVector? = null,
+) {
+    val headerInteraction = remember { MutableInteractionSource() }
+    val isHeaderHovered by headerInteraction.collectIsHoveredAsState()
+    val accent = JewelTheme.globalColors.outlines.focused
+    val headerBackground by animateColorAsState(
+        targetValue = if (isHeaderHovered) accent.copy(alpha = 0.06f) else Color.Transparent,
+        animationSpec = tween(durationMillis = 150),
+    )
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (expanded) 90f else 0f,
+        animationSpec = tween(durationMillis = 180),
+    )
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(headerBackground)
+                .then(
+                    if (onToggleExpand != null) {
+                        Modifier.clickable { onToggleExpand() }.hoverable(headerInteraction)
+                    } else {
+                        Modifier
+                    },
+                ).padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        if (onToggleExpand != null) {
+            Icon(
+                key = AllIconsKeys.General.ChevronRight,
+                contentDescription = null,
+                modifier = Modifier.size(12.dp).rotate(chevronRotation),
+                tint = JewelTheme.globalColors.text.info,
+            )
+        }
+        if (leadingIconKey != null) {
+            Icon(
+                key = leadingIconKey,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = JewelTheme.globalColors.text.info,
+            )
+        } else if (leadingIconVector != null) {
+            Image(
+                painter = rememberVectorPainter(leadingIconVector),
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                colorFilter = ColorFilter.tint(JewelTheme.globalColors.text.info),
+            )
+        }
+        Text(
+            text = title,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = JewelTheme.globalColors.text.normal,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        if (count != null) {
+            Text(
+                text = count.toString(),
+                fontSize = 12.sp,
+                color = JewelTheme.globalColors.text.info,
+            )
+        }
+        if (onDelete != null) {
+            DeleteButton(
+                visible = isHeaderHovered,
+                onClick = onDelete,
+            )
+        }
+    }
+}
+
+@Composable
+fun ListRow(
+    title: String,
+    onOpen: () -> Unit,
+    onDelete: () -> Unit,
+    leadingIconKey: IconKey? = null,
+    leadingIconVector: ImageVector? = null,
+    leadingTint: Color = JewelTheme.globalColors.outlines.focused,
+    leadingContent: @Composable (RowScope.() -> Unit)? = null,
+    showDivider: Boolean = true,
+    compact: Boolean = false,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    val accent = JewelTheme.globalColors.outlines.focused
+    val background by animateColorAsState(
+        targetValue = if (isHovered) accent.copy(alpha = 0.06f) else Color.Transparent,
+        animationSpec = tween(durationMillis = 140),
+    )
+
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(background)
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                        onClick = onOpen,
+                    ).hoverable(interactionSource)
+                    .padding(horizontal = 8.dp, vertical = if (compact) 5.dp else 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            leadingContent?.invoke(this)
+            if (leadingIconKey != null) {
+                Icon(
+                    key = leadingIconKey,
+                    contentDescription = null,
+                    modifier = Modifier.size(if (compact) 13.dp else 15.dp),
+                    tint = leadingTint,
+                )
+            } else if (leadingIconVector != null) {
+                Image(
+                    painter = rememberVectorPainter(leadingIconVector),
+                    contentDescription = null,
+                    modifier = Modifier.size(if (compact) 13.dp else 15.dp),
+                    colorFilter = ColorFilter.tint(leadingTint),
+                )
+            }
+            Text(
+                text = title,
+                fontSize = if (compact) 12.sp else 14.sp,
+                color = JewelTheme.globalColors.text.normal,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            DeleteButton(visible = isHovered, onClick = onDelete)
+        }
+        if (showDivider) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .padding(start = 28.dp)
+                        .background(
+                            JewelTheme.globalColors.borders.normal
+                                .copy(alpha = 0.5f),
+                        ).align(Alignment.BottomCenter),
+            )
+        }
+    }
+}
+
+@Composable
+fun DeleteButton(
+    visible: Boolean,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    val accent = JewelTheme.globalColors.outlines.focused
+    Box(
+        modifier =
+            Modifier
+                .size(22.dp)
+                .clip(CircleShape)
+                .background(if (isHovered) accent.copy(alpha = 0.12f) else Color.Transparent)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onClick,
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            key = AllIconsKeys.Actions.Close,
+            contentDescription = null,
+            modifier = Modifier.size(13.dp),
+            tint = if (visible || isHovered) JewelTheme.globalColors.text.normal else Color.Transparent,
+        )
+    }
+}
+
+@Composable
+fun EmptyState(
+    iconKey: IconKey,
+    message: String,
+) {
+    Box(modifier = Modifier.fillMaxWidth().padding(top = 80.dp), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Icon(
+                key = iconKey,
+                contentDescription = null,
+                modifier = Modifier.size(56.dp),
+                tint = JewelTheme.globalColors.borders.normal,
+            )
+            Text(
+                text = message,
+                fontSize = 15.sp,
+                color = JewelTheme.globalColors.text.info,
+            )
+        }
+    }
+}
+
+@Composable
+fun InlineTextField(
+    value: String,
+    placeholder: StringResource,
+    onValueChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = modifier,
+    ) {
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            singleLine = true,
+            textStyle = TextStyle(fontSize = 13.sp, color = JewelTheme.globalColors.text.normal),
+            cursorBrush = SolidColor(JewelTheme.globalColors.outlines.focused),
+            modifier =
+                Modifier
+                    .widthIn(min = 160.dp, max = 220.dp)
+                    .height(32.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .border(1.dp, JewelTheme.globalColors.borders.normal, RoundedCornerShape(6.dp))
+                    .background(JewelTheme.globalColors.panelBackground)
+                    .padding(horizontal = 10.dp)
+                    .focusRequester(focusRequester),
+            decorationBox = { innerTextField ->
+                Box(contentAlignment = Alignment.CenterStart, modifier = Modifier.fillMaxSize()) {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = stringResource(placeholder),
+                            fontSize = 13.sp,
+                            color = JewelTheme.globalColors.text.info,
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+        )
+        IconButton(
+            onClick = onConfirm,
+            modifier = Modifier.size(28.dp),
+            enabled = value.isNotBlank(),
+        ) {
+            Icon(
+                key = AllIconsKeys.Actions.Checked,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+        IconButton(
+            onClick = onCancel,
+            modifier = Modifier.size(28.dp),
+        ) {
+            Icon(
+                key = AllIconsKeys.Actions.Close,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Positions a popup directly below its anchor, aligning the popup's start edge with the
+ * anchor's start edge. Coordinates are clamped to the window bounds.
+ */
+internal object StartBelowAnchorPositionProvider : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val x =
+            if (layoutDirection == LayoutDirection.Ltr) {
+                anchorBounds.left
+            } else {
+                anchorBounds.right - popupContentSize.width
+            }
+        val y = anchorBounds.bottom
+        return IntOffset(
+            x = x.coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0)),
+            y = y.coerceIn(0, (windowSize.height - popupContentSize.height).coerceAtLeast(0)),
+        )
+    }
+}
+
+/**
+ * A compact popup for entering a single-line value. The text field receives focus automatically
+ * and Enter/Escape confirm/cancel.
+ */
+@Composable
+fun InputPopup(
+    title: String,
+    value: String,
+    placeholder: StringResource,
+    confirmText: String,
+    onValueChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    CardSurface(modifier = Modifier.width(240.dp)) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                text = title,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = JewelTheme.globalColors.text.normal,
+            )
+            BasicTextField(
+                value = value,
+                onValueChange = onValueChange,
+                singleLine = true,
+                textStyle = TextStyle(fontSize = 13.sp, color = JewelTheme.globalColors.text.normal),
+                cursorBrush = SolidColor(JewelTheme.globalColors.outlines.focused),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(32.dp)
+                        .clip(RoundedCornerShape(6.dp))
+                        .border(1.dp, JewelTheme.globalColors.borders.normal, RoundedCornerShape(6.dp))
+                        .background(JewelTheme.globalColors.panelBackground)
+                        .padding(horizontal = 10.dp)
+                        .focusRequester(focusRequester)
+                        .onKeyEvent { keyEvent ->
+                            when (keyEvent.key) {
+                                Key.Enter -> {
+                                    if (value.isNotBlank()) onConfirm()
+                                    true
+                                }
+                                Key.Escape -> {
+                                    onCancel()
+                                    true
+                                }
+                                else -> false
+                            }
+                        },
+                decorationBox = { innerTextField ->
+                    Box(contentAlignment = Alignment.CenterStart, modifier = Modifier.fillMaxSize()) {
+                        if (value.isEmpty()) {
+                            Text(
+                                text = stringResource(placeholder),
+                                fontSize = 13.sp,
+                                color = JewelTheme.globalColors.text.info,
+                            )
+                        }
+                        innerTextField()
+                    }
+                },
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedButton(onClick = onCancel) {
+                    Text(stringResource(Res.string.settings_cancel), fontSize = 12.sp)
+                }
+                DefaultButton(onClick = onConfirm, enabled = value.isNotBlank()) {
+                    Text(confirmText, fontSize = 12.sp)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A compact confirmation popup with title, message and cancel/confirm actions.
+ */
+@Composable
+fun ConfirmPopup(
+    title: String,
+    message: String,
+    confirmText: String,
+    cancelText: String,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    CardSurface(modifier = Modifier.width(260.dp)) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = title,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = JewelTheme.globalColors.text.normal,
+            )
+            Text(
+                text = message,
+                fontSize = 13.sp,
+                color = JewelTheme.globalColors.text.info,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedButton(onClick = onCancel) {
+                    Text(cancelText, fontSize = 12.sp)
+                }
+                DefaultButton(onClick = onConfirm) {
+                    Text(confirmText, fontSize = 12.sp)
+                }
+            }
+        }
+    }
+}

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/TabSearchPopup.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/TabSearchPopup.kt
@@ -342,6 +342,13 @@ private fun PopupRow(
                     modifier = Modifier.size(15.dp),
                     tint = JewelTheme.globalColors.text.normal,
                 )
+            TabType.FAVORITES ->
+                Icon(
+                    key = AllIconsKeys.Nodes.Favorite,
+                    contentDescription = null,
+                    modifier = Modifier.size(15.dp),
+                    tint = JewelTheme.globalColors.text.normal,
+                )
             TabType.SEARCH ->
                 Icon(
                     key = AllIconsKeys.Actions.Find,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsContent.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsContent.kt
@@ -43,6 +43,7 @@ import io.github.kdroidfilter.seforimapp.features.bookcontent.BookContentScreen
 import io.github.kdroidfilter.seforimapp.features.bookcontent.BookContentViewModel
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.StateKeys
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.panels.bookcontent.views.HomeSearchCallbacks
+import io.github.kdroidfilter.seforimapp.features.favorites.FavoritesTabContent
 import io.github.kdroidfilter.seforimapp.features.history.HistoryTabContent
 import io.github.kdroidfilter.seforimapp.features.search.SearchHomeNavigationEvent
 import io.github.kdroidfilter.seforimapp.features.search.SearchResultInBookShellMvi
@@ -72,6 +73,7 @@ private fun TabsDestination.typeKey(): String =
         is TabsDestination.Search -> "search"
         is TabsDestination.BookContent -> "book"
         is TabsDestination.History -> "history"
+        is TabsDestination.Favorites -> "favorites"
     }
 
 private fun saveableKeyFor(destination: TabsDestination): String = "${destination.tabId}:${destination.typeKey()}"
@@ -300,6 +302,10 @@ fun TabsContent() {
 
                                 is TabsDestination.History -> {
                                     HistoryTabContent(tabId = tabId)
+                                }
+
+                                is TabsDestination.Favorites -> {
+                                    FavoritesTabContent(tabId = tabId)
                                 }
                             }
                         }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
@@ -165,6 +165,9 @@ private fun DefaultTabShowcase(
                                         } else if (tabItem.tabType == TabType.HISTORY) {
                                             val iconProvider = rememberResourcePainterProvider(AllIconsKeys.Vcs.History)
                                             iconProvider.getPainter(Stateful(tabState)).value
+                                        } else if (tabItem.tabType == TabType.FAVORITES) {
+                                            val iconProvider = rememberResourcePainterProvider(AllIconsKeys.Nodes.Favorite)
+                                            iconProvider.getPainter(Stateful(tabState)).value
                                         } else {
                                             if (tabItem.title.isEmpty()) {
                                                 rememberVectorPainter(
@@ -237,6 +240,9 @@ private fun DefaultTabShowcase(
                                             rememberVectorPainter(bookOpenTabs(JewelTheme.globalColors.text.normal))
                                         } else if (tabItem.tabType == TabType.HISTORY) {
                                             val iconProvider = rememberResourcePainterProvider(AllIconsKeys.Vcs.History)
+                                            iconProvider.getPainter(Stateful(tabState)).value
+                                        } else if (tabItem.tabType == TabType.FAVORITES) {
+                                            val iconProvider = rememberResourcePainterProvider(AllIconsKeys.Nodes.Favorite)
                                             iconProvider.getPainter(Stateful(tabState)).value
                                         } else {
                                             if (tabItem.title.isEmpty()) {

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/window/MainAppWindow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/window/MainAppWindow.kt
@@ -86,6 +86,18 @@ fun NucleusApplicationScope.MainAppWindow(
         }
     }
 
+    // Chrome-like favorites shortcut (Cmd+Alt+B on macOS, Ctrl+Shift+O elsewhere): select the
+    // window's Favorites tab when one is open, otherwise open it.
+    val openFavoritesTab = {
+        val currentTabs = tabsVm.state.value.tabs
+        val existing = currentTabs.indexOfFirst { it.destination is TabsDestination.Favorites }
+        if (existing >= 0) {
+            tabsVm.onEvent(TabsEvents.OnSelect(existing))
+        } else {
+            tabsVm.openTab(TabsDestination.Favorites(tabId = UUID.randomUUID().toString()))
+        }
+    }
+
     val tabsState by tabsVm.state.collectAsState()
     val tabs = tabsState.tabs
     val selectedIndex = tabsState.selectedTabIndex
@@ -149,6 +161,12 @@ fun NucleusApplicationScope.MainAppWindow(
                     (!PlatformInfo.isMacOS && keyEvent.isCtrlPressed && !keyEvent.isShiftPressed && keyEvent.key == Key.H)
                 ) {
                     openHistoryTab()
+                    true
+                } else if (
+                    (PlatformInfo.isMacOS && keyEvent.isMetaPressed && keyEvent.isAltPressed && keyEvent.key == Key.B) ||
+                    (!PlatformInfo.isMacOS && keyEvent.isCtrlPressed && keyEvent.isShiftPressed && keyEvent.key == Key.O)
+                ) {
+                    openFavoritesTab()
                     true
                 } else if (isCtrlOrCmd && keyEvent.key == Key.T) {
                     tabsVm.onEvent(TabsEvents.OnAdd)
@@ -293,6 +311,18 @@ fun NucleusApplicationScope.MainAppWindow(
                                         )
                                     -> {
                                         openHistoryTab()
+                                        true
+                                    }
+                                    // Cmd+Alt+B (macOS) / Ctrl+Shift+O (others) => favorites page (Chrome-like)
+                                    (PlatformInfo.isMacOS && keyEvent.isMetaPressed && keyEvent.isAltPressed && keyEvent.key == Key.B) ||
+                                        (
+                                            !PlatformInfo.isMacOS &&
+                                                keyEvent.isCtrlPressed &&
+                                                keyEvent.isShiftPressed &&
+                                                keyEvent.key == Key.O
+                                        )
+                                    -> {
+                                        openFavoritesTab()
                                         true
                                     }
                                     // Ctrl/Cmd + T => new tab

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/BookContentPanel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/BookContentPanel.kt
@@ -405,11 +405,17 @@ private fun BreadcrumbSection(
         }
     Column(modifier = sectionModifier) {
         if (!isIslands) HorizontalDivider()
-        BreadcrumbView(
-            uiState = uiState,
-            onEvent = onEvent,
+        Row(
             modifier = Modifier.fillMaxWidth().padding(vertical = verticalPadding, horizontal = 16.dp),
-        )
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BreadcrumbView(
+                uiState = uiState,
+                onEvent = onEvent,
+                modifier = Modifier.weight(1f),
+            )
+            BreadcrumbActionsView(uiState = uiState)
+        }
     }
 }
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BreadcrumbActionsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BreadcrumbActionsView.kt
@@ -1,0 +1,510 @@
+@file:OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
+
+package io.github.kdroidfilter.seforimapp.features.bookcontent.ui.panels.bookcontent.views
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.TooltipPlacement
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import io.github.kdroidfilter.seforimapp.core.deeplink.bookShareLink
+import io.github.kdroidfilter.seforimapp.core.favorites.FavoriteFolder
+import io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookContentState
+import io.github.kdroidfilter.seforimapp.framework.di.LocalAppGraph
+import io.github.kdroidfilter.seforimapp.icons.Link
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.IconButton
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.Tooltip
+import org.jetbrains.jewel.ui.icons.AllIconsKeys
+import seforimapp.seforimapp.generated.resources.Res
+import seforimapp.seforimapp.generated.resources.breadcrumb_copy_link
+import seforimapp.seforimapp.generated.resources.favorites_add
+import seforimapp.seforimapp.generated.resources.favorites_edit
+import seforimapp.seforimapp.generated.resources.favorites_folder_name_placeholder
+import seforimapp.seforimapp.generated.resources.favorites_new_folder
+import seforimapp.seforimapp.generated.resources.favorites_no_folder
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+
+/**
+ * Action buttons at the end of the breadcrumb bar (Chrome omnibox-like): copy a deep link to
+ * the current position, and star/unstar it as a favorite with a folder-picking popup.
+ */
+@Composable
+fun BreadcrumbActionsView(uiState: BookContentState) {
+    val book = uiState.navigation.selectedBook ?: return
+    val toc = uiState.toc.breadcrumbPath.lastOrNull()
+    val lineId = uiState.content.primaryLine?.id ?: toc?.lineId
+
+    val aboveAnchorPlacement =
+        remember {
+            object : TooltipPlacement {
+                @Composable
+                override fun positionProvider(cursorPosition: Offset): PopupPositionProvider =
+                    object : PopupPositionProvider {
+                        override fun calculatePosition(
+                            anchorBounds: IntRect,
+                            windowSize: IntSize,
+                            layoutDirection: LayoutDirection,
+                            popupContentSize: IntSize,
+                        ): IntOffset =
+                            IntOffset(
+                                x =
+                                    (anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2)
+                                        .coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0)),
+                                y = anchorBounds.top - popupContentSize.height,
+                            )
+                    }
+            }
+        }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        CopyLinkButton(
+            bookId = book.id,
+            lineId = lineId,
+            tooltipPlacement = aboveAnchorPlacement,
+        )
+        FavoriteStarButton(
+            bookId = book.id,
+            tocEntryId = toc?.id,
+            lineId = lineId,
+            title =
+                toc
+                    ?.text
+                    ?.takeIf { it.isNotBlank() && it != book.title }
+                    ?.let { "${book.title} - $it" } ?: book.title,
+            tooltipPlacement = aboveAnchorPlacement,
+        )
+    }
+}
+
+@Composable
+private fun CopyLinkButton(
+    bookId: Long,
+    lineId: Long?,
+    tooltipPlacement: TooltipPlacement,
+) {
+    var copied by remember { mutableStateOf(false) }
+    LaunchedEffect(copied) {
+        if (copied) {
+            delay(COPIED_FEEDBACK_MS)
+            copied = false
+        }
+    }
+    Tooltip(
+        tooltip = { Text(stringResource(Res.string.breadcrumb_copy_link), fontSize = 13.sp) },
+        tooltipPlacement = tooltipPlacement,
+    ) {
+        IconButton(
+            onClick = {
+                Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(bookShareLink(bookId, lineId)), null)
+                copied = true
+            },
+            modifier = Modifier.size(24.dp),
+        ) {
+            if (copied) {
+                Icon(
+                    key = AllIconsKeys.Actions.Checked,
+                    contentDescription = stringResource(Res.string.breadcrumb_copy_link),
+                    modifier = Modifier.size(16.dp),
+                )
+            } else {
+                // Same chain-link vector as the tab context menu's copy-link item
+                Image(
+                    painter = rememberVectorPainter(Link),
+                    contentDescription = stringResource(Res.string.breadcrumb_copy_link),
+                    modifier = Modifier.size(16.dp),
+                    colorFilter = ColorFilter.tint(JewelTheme.globalColors.text.normal),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FavoriteStarButton(
+    bookId: Long,
+    tocEntryId: Long?,
+    lineId: Long?,
+    title: String,
+    tooltipPlacement: TooltipPlacement,
+) {
+    val favoritesStore = LocalAppGraph.current.favoritesStore
+    val scope = rememberCoroutineScope()
+    val revision by favoritesStore.revision.collectAsState()
+    val key = favoritesStore.keyFor(bookId, tocEntryId)
+    var isFavorite by remember { mutableStateOf(false) }
+    LaunchedEffect(key, revision) { isFavorite = favoritesStore.isFavorite(key) }
+    var popupVisible by remember { mutableStateOf(false) }
+
+    Box(
+        modifier =
+            Modifier.onPointerEvent(PointerEventType.Press) { event ->
+                if (event.buttons.isSecondaryPressed) {
+                    scope.launch {
+                        if (!isFavorite) {
+                            favoritesStore.add(bookId, title, System.currentTimeMillis(), tocEntryId, lineId)
+                        }
+                        popupVisible = true
+                    }
+                }
+            },
+    ) {
+        val starLabel = stringResource(if (isFavorite) Res.string.favorites_edit else Res.string.favorites_add)
+        Tooltip(
+            tooltip = { Text(starLabel, fontSize = 13.sp) },
+            tooltipPlacement = tooltipPlacement,
+        ) {
+            IconButton(
+                onClick = {
+                    scope.launch {
+                        if (isFavorite) {
+                            favoritesStore.remove(key)
+                        } else {
+                            favoritesStore.add(bookId, title, System.currentTimeMillis(), tocEntryId, lineId)
+                        }
+                    }
+                },
+                modifier = Modifier.size(24.dp),
+            ) {
+                Icon(
+                    key = if (isFavorite) AllIconsKeys.Nodes.Favorite else AllIconsKeys.Nodes.NotFavoriteOnHover,
+                    contentDescription = starLabel,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+        }
+        if (popupVisible) {
+            Popup(
+                popupPositionProvider = AboveAnchorPositionProvider,
+                onDismissRequest = { popupVisible = false },
+                properties = PopupProperties(focusable = true),
+            ) {
+                FavoritePopupContent(
+                    favoriteKey = key,
+                    title = title,
+                    onDismiss = { popupVisible = false },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FavoritePopupContent(
+    favoriteKey: String,
+    title: String,
+    onDismiss: () -> Unit,
+) {
+    val favoritesStore = LocalAppGraph.current.favoritesStore
+    val scope = rememberCoroutineScope()
+    val revision by favoritesStore.revision.collectAsState()
+    var folders by remember { mutableStateOf<List<FavoriteFolder>>(emptyList()) }
+    var selectedFolderId by remember { mutableStateOf<Long?>(null) }
+    LaunchedEffect(revision) {
+        folders = favoritesStore.folders()
+        selectedFolderId = favoritesStore.get(favoriteKey)?.folderId
+    }
+
+    fun moveTo(folderId: Long?) {
+        selectedFolderId = folderId
+        scope.launch { favoritesStore.setFolder(favoriteKey, folderId) }
+    }
+
+    Column(
+        modifier =
+            Modifier
+                .width(260.dp)
+                .background(JewelTheme.globalColors.panelBackground, RoundedCornerShape(8.dp))
+                .border(1.dp, JewelTheme.globalColors.borders.normal, RoundedCornerShape(8.dp))
+                .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = title,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = JewelTheme.globalColors.text.normal,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        FolderChoiceRow(
+            label = stringResource(Res.string.favorites_no_folder),
+            selected = selectedFolderId == null,
+            onClick = {
+                moveTo(null)
+                onDismiss()
+            },
+        )
+        folders.forEach { folder ->
+            FolderChoiceRow(
+                label = folder.name,
+                selected = selectedFolderId == folder.id,
+                onClick = {
+                    moveTo(folder.id)
+                    onDismiss()
+                },
+            )
+        }
+
+        NewFolderRow(
+            onCreate = { name ->
+                scope.launch {
+                    val id = favoritesStore.createFolder(name, System.currentTimeMillis())
+                    favoritesStore.setFolder(favoriteKey, id)
+                    onDismiss()
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun FolderChoiceRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val hoverSource = remember { MutableInteractionSource() }
+    val isHovered by hoverSource.collectIsHoveredAsState()
+    val accent = JewelTheme.globalColors.outlines.focused
+    val backgroundColor by animateColorAsState(
+        targetValue =
+            when {
+                selected -> accent.copy(alpha = 0.12f)
+                isHovered -> accent.copy(alpha = 0.08f)
+                else -> Color.Transparent
+            },
+        animationSpec = tween(durationMillis = 150),
+    )
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(6.dp))
+                .background(backgroundColor)
+                .clickable(
+                    onClick = onClick,
+                    indication = null,
+                    interactionSource = hoverSource,
+                ).pointerHoverIcon(PointerIcon.Hand)
+                .padding(horizontal = 8.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            key = AllIconsKeys.Nodes.Folder,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = JewelTheme.globalColors.text.info,
+        )
+        Text(
+            text = label,
+            fontSize = 13.sp,
+            color = JewelTheme.globalColors.text.normal,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        if (selected) {
+            Icon(
+                key = AllIconsKeys.Actions.Checked,
+                contentDescription = null,
+                modifier = Modifier.size(14.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun NewFolderRow(onCreate: (String) -> Unit) {
+    var editing by remember { mutableStateOf(false) }
+    var name by remember { mutableStateOf("") }
+
+    if (!editing) {
+        val hoverSource = remember { MutableInteractionSource() }
+        val isHovered by hoverSource.collectIsHoveredAsState()
+        val accent = JewelTheme.globalColors.outlines.focused
+        val backgroundColor by animateColorAsState(
+            targetValue = if (isHovered) accent.copy(alpha = 0.08f) else Color.Transparent,
+            animationSpec = tween(durationMillis = 150),
+        )
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(backgroundColor)
+                    .clickable(
+                        onClick = { editing = true },
+                        indication = null,
+                        interactionSource = hoverSource,
+                    ).pointerHoverIcon(PointerIcon.Hand)
+                    .padding(horizontal = 8.dp, vertical = 5.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                key = AllIconsKeys.General.Add,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = JewelTheme.globalColors.text.info,
+            )
+            Text(
+                text = stringResource(Res.string.favorites_new_folder),
+                fontSize = 13.sp,
+                color = JewelTheme.globalColors.text.normal,
+            )
+        }
+    } else {
+        val focusRequester = remember { FocusRequester() }
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+        fun confirm() {
+            if (name.isNotBlank()) onCreate(name.trim())
+            name = ""
+            editing = false
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            BasicTextField(
+                value = name,
+                onValueChange = { name = it },
+                singleLine = true,
+                textStyle = TextStyle(fontSize = 13.sp, color = JewelTheme.globalColors.text.normal),
+                cursorBrush = SolidColor(JewelTheme.globalColors.outlines.focused),
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .background(JewelTheme.globalColors.panelBackground, RoundedCornerShape(6.dp))
+                        .border(1.dp, JewelTheme.globalColors.borders.normal, RoundedCornerShape(6.dp))
+                        .padding(horizontal = 8.dp, vertical = 6.dp)
+                        .focusRequester(focusRequester)
+                        .onPreviewKeyEvent { event ->
+                            when {
+                                event.type == KeyEventType.KeyDown && event.key == Key.Enter -> {
+                                    confirm()
+                                    true
+                                }
+                                event.type == KeyEventType.KeyDown && event.key == Key.Escape -> {
+                                    name = ""
+                                    editing = false
+                                    true
+                                }
+                                else -> false
+                            }
+                        },
+                decorationBox = { innerTextField ->
+                    Box {
+                        if (name.isEmpty()) {
+                            Text(
+                                text = stringResource(Res.string.favorites_folder_name_placeholder),
+                                fontSize = 13.sp,
+                                color = JewelTheme.globalColors.text.info,
+                            )
+                        }
+                        innerTextField()
+                    }
+                },
+            )
+            IconButton(
+                onClick = ::confirm,
+                modifier = Modifier.size(28.dp),
+                enabled = name.isNotBlank(),
+            ) {
+                Icon(
+                    key = AllIconsKeys.Actions.Checked,
+                    contentDescription = stringResource(Res.string.favorites_new_folder),
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+        }
+    }
+}
+
+/** Places the popup above its anchor, aligned to the anchor's leading edge. */
+private object AboveAnchorPositionProvider : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val x = anchorBounds.left
+        val y = anchorBounds.top - popupContentSize.height
+        return IntOffset(
+            x = x.coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0)),
+            y = y.coerceIn(0, (windowSize.height - popupContentSize.height).coerceAtLeast(0)),
+        )
+    }
+}
+
+private const val COPIED_FEEDBACK_MS = 1_500L

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BreadcrumbView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BreadcrumbView.kt
@@ -82,7 +82,7 @@ fun BreadcrumbView(
     Row(
         modifier = modifier.horizontalScroll(scrollState),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.End,
+        horizontalArrangement = Arrangement.Start,
     ) {
         // Display each item in the breadcrumb path
         breadcrumbPath.forEachIndexed { index, item ->

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/favorites/FavoritesScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/favorites/FavoritesScreen.kt
@@ -1,0 +1,387 @@
+@file:OptIn(ExperimentalLayoutApi::class, ExperimentalComposeUiApi::class)
+
+package io.github.kdroidfilter.seforimapp.features.favorites
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import io.github.kdroidfilter.seforim.tabs.TabType
+import io.github.kdroidfilter.seforim.tabs.TabsDestination
+import io.github.kdroidfilter.seforimapp.core.favorites.FavoriteEntry
+import io.github.kdroidfilter.seforimapp.core.favorites.FavoriteFolder
+import io.github.kdroidfilter.seforimapp.core.presentation.components.CardSurface
+import io.github.kdroidfilter.seforimapp.core.presentation.components.EmptyState
+import io.github.kdroidfilter.seforimapp.core.presentation.components.InputPopup
+import io.github.kdroidfilter.seforimapp.core.presentation.components.ListPageContainer
+import io.github.kdroidfilter.seforimapp.core.presentation.components.ListRow
+import io.github.kdroidfilter.seforimapp.core.presentation.components.PageHeader
+import io.github.kdroidfilter.seforimapp.core.presentation.components.PageSearchField
+import io.github.kdroidfilter.seforimapp.core.presentation.components.SectionHeader
+import io.github.kdroidfilter.seforimapp.core.presentation.components.StartBelowAnchorPositionProvider
+import io.github.kdroidfilter.seforimapp.framework.desktop.LocalOpenWindow
+import io.github.kdroidfilter.seforimapp.framework.di.LocalAppGraph
+import io.github.kdroidfilter.seforimapp.logger.debugln
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.IconButton
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.icons.AllIconsKeys
+import seforimapp.seforimapp.generated.resources.Res
+import seforimapp.seforimapp.generated.resources.favorites_create_folder
+import seforimapp.seforimapp.generated.resources.favorites_empty
+import seforimapp.seforimapp.generated.resources.favorites_folder_name_placeholder
+import seforimapp.seforimapp.generated.resources.favorites_new_folder
+import seforimapp.seforimapp.generated.resources.favorites_no_folder
+import seforimapp.seforimapp.generated.resources.favorites_search_placeholder
+import seforimapp.seforimapp.generated.resources.favorites_title
+import java.util.UUID
+
+/**
+ * Favorites page: a space-efficient, Jewel-styled bookmark manager.
+ * Unfiled favorites are shown as a flat list at the top. Folder favorites are grouped
+ * into collapsible cards. Everything is reachable through search and right-click context.
+ */
+@Composable
+fun FavoritesTabContent(tabId: String) {
+    val appGraph = LocalAppGraph.current
+    val favoritesStore = appGraph.favoritesStore
+    val tabsViewModel = LocalOpenWindow.current.tabsViewModel
+    val scope = rememberCoroutineScope()
+
+    val favoritesTitle = stringResource(Res.string.favorites_title)
+    LaunchedEffect(tabId, favoritesTitle) {
+        appGraph.tabTitleUpdateManager.updateTabTitle(tabId, favoritesTitle, TabType.FAVORITES)
+    }
+
+    var query by remember { mutableStateOf("") }
+    val revision by favoritesStore.revision.collectAsState()
+    var entries by remember { mutableStateOf<List<FavoriteEntry>>(emptyList()) }
+    var folders by remember { mutableStateOf<List<FavoriteFolder>>(emptyList()) }
+    LaunchedEffect(query, revision) {
+        entries = favoritesStore.query(query)
+        folders = favoritesStore.folders()
+    }
+
+    fun openEntry(entry: FavoriteEntry) {
+        debugln { "[Favorites] open ${entry.key}" }
+        tabsViewModel.replaceCurrentTabWithNewTabId(
+            TabsDestination.BookContent(bookId = entry.bookId, tabId = UUID.randomUUID().toString(), lineId = entry.lineId),
+        )
+    }
+
+    FavoritesPageContent(
+        query = query,
+        onQueryChange = { query = it },
+        entries = entries,
+        folders = folders,
+        onOpen = ::openEntry,
+        onDelete = { entry -> scope.launch { favoritesStore.remove(entry.key) } },
+        onCreateFolder = { name -> scope.launch { favoritesStore.createFolder(name, System.currentTimeMillis()) } },
+        onDeleteFolder = { folder -> scope.launch { favoritesStore.deleteFolder(folder.id) } },
+        onMoveToFolder = { entry, folderId -> scope.launch { favoritesStore.setFolder(entry.key, folderId) } },
+    )
+}
+
+@Composable
+private fun FavoritesPageContent(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    entries: List<FavoriteEntry>,
+    folders: List<FavoriteFolder>,
+    onOpen: (FavoriteEntry) -> Unit,
+    onDelete: (FavoriteEntry) -> Unit,
+    onCreateFolder: (String) -> Unit,
+    onDeleteFolder: (FavoriteFolder) -> Unit,
+    onMoveToFolder: (FavoriteEntry, Long?) -> Unit,
+) {
+    val byFolder = remember(entries) { entries.groupBy { it.folderId } }
+    val unfiled = byFolder[null].orEmpty()
+    val accent = JewelTheme.globalColors.outlines.focused
+
+    ListPageContainer {
+        PageHeader(
+            title = stringResource(Res.string.favorites_title),
+            actions = { NewFolderButton(onCreate = onCreateFolder) },
+        )
+
+        PageSearchField(
+            query = query,
+            placeholder = Res.string.favorites_search_placeholder,
+            onQueryChange = onQueryChange,
+        )
+
+        if (entries.isEmpty() && folders.isEmpty()) {
+            EmptyState(
+                iconKey = AllIconsKeys.Nodes.NotFavoriteOnHover,
+                message = stringResource(Res.string.favorites_empty),
+            )
+        } else {
+            if (folders.isNotEmpty()) {
+                FlowRow(
+                    modifier = Modifier.widthIn(max = 720.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.Start),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    maxItemsInEachRow = 2,
+                ) {
+                    folders.forEach { folder ->
+                        val folderEntries = byFolder[folder.id].orEmpty()
+                        if (query.isNotBlank() && folderEntries.isEmpty()) return@forEach
+                        FolderCard(
+                            folder = folder,
+                            entries = folderEntries,
+                            onOpen = onOpen,
+                            onDeleteEntry = onDelete,
+                            onDeleteFolder = onDeleteFolder,
+                            onMoveToFolder = onMoveToFolder,
+                            allFolders = folders,
+                            accent = accent,
+                        )
+                    }
+                }
+            }
+
+            if (unfiled.isNotEmpty()) {
+                Text(
+                    text = stringResource(Res.string.favorites_no_folder),
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = JewelTheme.globalColors.text.info,
+                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
+                )
+                CardSurface {
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        unfiled.forEachIndexed { index, entry ->
+                            FavoriteRowWithContextMenu(
+                                entry = entry,
+                                folders = folders,
+                                onOpen = { onOpen(entry) },
+                                onDelete = { onDelete(entry) },
+                                onMoveToFolder = { id -> onMoveToFolder(entry, id) },
+                                showDivider = index < unfiled.lastIndex,
+                                accent = accent,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NewFolderButton(onCreate: (String) -> Unit) {
+    var showPopup by remember { mutableStateOf(false) }
+    var name by remember { mutableStateOf("") }
+
+    Box {
+        IconButton(
+            onClick = {
+                showPopup = true
+                name = ""
+            },
+            modifier = Modifier.size(32.dp),
+        ) {
+            Icon(
+                key = AllIconsKeys.General.Add,
+                contentDescription = stringResource(Res.string.favorites_new_folder),
+                modifier = Modifier.size(18.dp),
+            )
+        }
+
+        if (showPopup) {
+            Popup(
+                onDismissRequest = { showPopup = false },
+                popupPositionProvider = StartBelowAnchorPositionProvider,
+                properties = PopupProperties(focusable = true),
+            ) {
+                InputPopup(
+                    title = stringResource(Res.string.favorites_new_folder),
+                    value = name,
+                    placeholder = Res.string.favorites_folder_name_placeholder,
+                    confirmText = stringResource(Res.string.favorites_create_folder),
+                    onValueChange = { name = it },
+                    onConfirm = {
+                        if (name.isNotBlank()) onCreate(name.trim())
+                        showPopup = false
+                        name = ""
+                    },
+                    onCancel = {
+                        showPopup = false
+                        name = ""
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FolderCard(
+    folder: FavoriteFolder,
+    entries: List<FavoriteEntry>,
+    onOpen: (FavoriteEntry) -> Unit,
+    onDeleteEntry: (FavoriteEntry) -> Unit,
+    onDeleteFolder: (FavoriteFolder) -> Unit,
+    onMoveToFolder: (FavoriteEntry, Long?) -> Unit,
+    allFolders: List<FavoriteFolder>,
+    accent: Color,
+) {
+    var expanded by remember { mutableStateOf(true) }
+
+    CardSurface(modifier = Modifier.widthIn(min = 220.dp, max = 320.dp)) {
+        Column {
+            SectionHeader(
+                title = folder.name,
+                count = entries.size,
+                expanded = expanded,
+                onToggleExpand = { expanded = !expanded },
+                onDelete = { onDeleteFolder(folder) },
+                leadingIconKey = AllIconsKeys.Nodes.Folder,
+            )
+
+            if (expanded && entries.isNotEmpty()) {
+                Column(
+                    modifier = Modifier.padding(start = 10.dp, end = 10.dp, bottom = 6.dp),
+                    verticalArrangement = Arrangement.spacedBy(1.dp),
+                ) {
+                    entries.forEachIndexed { index, entry ->
+                        FavoriteRowWithContextMenu(
+                            entry = entry,
+                            folders = allFolders,
+                            onOpen = { onOpen(entry) },
+                            onDelete = { onDeleteEntry(entry) },
+                            onMoveToFolder = { id -> onMoveToFolder(entry, id) },
+                            compact = true,
+                            showDivider = index < entries.lastIndex,
+                            accent = accent,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FavoriteRowWithContextMenu(
+    entry: FavoriteEntry,
+    folders: List<FavoriteFolder>,
+    onOpen: () -> Unit,
+    onDelete: () -> Unit,
+    onMoveToFolder: (Long?) -> Unit,
+    accent: Color,
+    compact: Boolean = false,
+    showDivider: Boolean = true,
+) {
+    var contextMenuOpen by remember { mutableStateOf(false) }
+
+    Box(
+        modifier =
+            Modifier
+                .onPointerEvent(PointerEventType.Press) { event ->
+                    if (event.buttons.isSecondaryPressed) contextMenuOpen = true
+                },
+    ) {
+        ListRow(
+            title = entry.title,
+            onOpen = onOpen,
+            onDelete = onDelete,
+            leadingIconKey = AllIconsKeys.Nodes.Favorite,
+            leadingTint = accent,
+            compact = compact,
+            showDivider = showDivider,
+        )
+
+        if (contextMenuOpen) {
+            FolderMovePopup(
+                folders = folders,
+                currentFolderId = entry.folderId,
+                onMove = { onMoveToFolder(it) },
+                onDismiss = { contextMenuOpen = false },
+            )
+        }
+    }
+}
+
+@Composable
+private fun FolderMovePopup(
+    folders: List<FavoriteFolder>,
+    currentFolderId: Long?,
+    onMove: (Long?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Popup(
+        popupPositionProvider = StartBelowAnchorPositionProvider,
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true),
+    ) {
+        CardSurface(modifier = Modifier.widthIn(max = 220.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = stringResource(Res.string.favorites_no_folder),
+                    fontSize = 13.sp,
+                    fontWeight = if (currentFolderId == null) FontWeight.SemiBold else FontWeight.Normal,
+                    color = JewelTheme.globalColors.text.normal,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(6.dp))
+                            .clickable {
+                                onMove(null)
+                                onDismiss()
+                            }.padding(horizontal = 8.dp, vertical = 6.dp),
+                )
+                folders.forEach { folder ->
+                    Text(
+                        text = folder.name,
+                        fontSize = 13.sp,
+                        fontWeight = if (currentFolderId == folder.id) FontWeight.SemiBold else FontWeight.Normal,
+                        color = JewelTheme.globalColors.text.normal,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(6.dp))
+                                .clickable {
+                                    onMove(folder.id)
+                                    onDismiss()
+                                }.padding(horizontal = 8.dp, vertical = 6.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/history/HistoryScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/history/HistoryScreen.kt
@@ -1,26 +1,12 @@
 package io.github.kdroidfilter.seforimapp.features.history
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.hoverable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -29,21 +15,24 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import io.github.kdroidfilter.seforim.tabs.TabType
 import io.github.kdroidfilter.seforim.tabs.TabsDestination
 import io.github.kdroidfilter.seforimapp.core.history.VisitEntry
 import io.github.kdroidfilter.seforimapp.core.history.VisitKind
+import io.github.kdroidfilter.seforimapp.core.presentation.components.CardSurface
+import io.github.kdroidfilter.seforimapp.core.presentation.components.ConfirmPopup
+import io.github.kdroidfilter.seforimapp.core.presentation.components.EmptyState
+import io.github.kdroidfilter.seforimapp.core.presentation.components.ListPageContainer
+import io.github.kdroidfilter.seforimapp.core.presentation.components.ListRow
+import io.github.kdroidfilter.seforimapp.core.presentation.components.PageHeader
+import io.github.kdroidfilter.seforimapp.core.presentation.components.PageSearchField
+import io.github.kdroidfilter.seforimapp.core.presentation.components.SectionHeader
+import io.github.kdroidfilter.seforimapp.core.presentation.components.StartBelowAnchorPositionProvider
 import io.github.kdroidfilter.seforimapp.framework.desktop.LocalOpenWindow
 import io.github.kdroidfilter.seforimapp.framework.di.LocalAppGraph
 import io.github.kdroidfilter.seforimapp.icons.bookOpenTabs
@@ -52,15 +41,19 @@ import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.Icon
-import org.jetbrains.jewel.ui.component.OutlinedButton
+import org.jetbrains.jewel.ui.component.IconButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import seforimapp.seforimapp.generated.resources.Res
 import seforimapp.seforimapp.generated.resources.history_clear_all
+import seforimapp.seforimapp.generated.resources.history_clear_confirm_message
+import seforimapp.seforimapp.generated.resources.history_clear_confirm_title
+import seforimapp.seforimapp.generated.resources.history_clear_confirm_yes
 import seforimapp.seforimapp.generated.resources.history_empty
 import seforimapp.seforimapp.generated.resources.history_title
 import seforimapp.seforimapp.generated.resources.history_today
 import seforimapp.seforimapp.generated.resources.history_yesterday
+import seforimapp.seforimapp.generated.resources.settings_cancel
 import seforimapp.seforimapp.generated.resources.tab_search_placeholder
 import java.time.Instant
 import java.time.LocalDate
@@ -133,194 +126,147 @@ private fun HistoryPageContent(
     onOpen: (VisitEntry) -> Unit,
     onDelete: (VisitEntry) -> Unit,
 ) {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.TopCenter) {
-        Column(
-            modifier =
-                Modifier
-                    .widthIn(max = 720.dp)
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = historyTitle,
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    color = JewelTheme.globalColors.text.normal,
-                    modifier = Modifier.weight(1f),
-                )
-                OutlinedButton(onClick = onClearAll) {
-                    Text(stringResource(Res.string.history_clear_all))
-                }
-            }
+    val zone = remember { ZoneId.systemDefault() }
+    val today = remember { LocalDate.now(zone) }
+    val dateFormatter = remember { DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.getDefault()) }
+    val timeFormatter = remember { DateTimeFormatter.ofPattern("HH:mm") }
+    val todayLabel = stringResource(Res.string.history_today)
+    val yesterdayLabel = stringResource(Res.string.history_yesterday)
 
-            HistorySearchField(query = query, onQueryChange = onQueryChange)
-
-            if (entries.isEmpty()) {
-                Box(modifier = Modifier.fillMaxWidth().padding(top = 48.dp), contentAlignment = Alignment.Center) {
-                    Text(
-                        text = stringResource(Res.string.history_empty),
-                        color = JewelTheme.globalColors.text.info,
-                    )
-                }
-            } else {
-                val zone = remember { ZoneId.systemDefault() }
-                val grouped =
-                    remember(entries) {
-                        entries.groupBy { Instant.ofEpochMilli(it.visitedAt).atZone(zone).toLocalDate() }
-                    }
-                val today = LocalDate.now(zone)
-                val dateFormatter = remember { DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.getDefault()) }
-                val todayLabel = stringResource(Res.string.history_today)
-                val yesterdayLabel = stringResource(Res.string.history_yesterday)
-
-                LazyColumn(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    grouped.forEach { (day, dayEntries) ->
-                        item(key = "day-$day") {
-                            Text(
-                                text =
-                                    when (day) {
-                                        today -> todayLabel
-                                        today.minusDays(1) -> yesterdayLabel
-                                        else -> day.format(dateFormatter)
-                                    },
-                                fontSize = 13.sp,
-                                fontWeight = FontWeight.SemiBold,
-                                color = JewelTheme.globalColors.text.info,
-                                modifier = Modifier.padding(top = 14.dp, bottom = 4.dp),
-                            )
-                        }
-                        items(dayEntries, key = { it.key }) { entry ->
-                            HistoryRow(
-                                entry = entry,
-                                zone = zone,
-                                onOpen = { onOpen(entry) },
-                                onDelete = { onDelete(entry) },
-                            )
-                        }
-                    }
-                }
-            }
-        }
+    val grouped = remember(entries) { entries.groupBy { Instant.ofEpochMilli(it.visitedAt).atZone(zone).toLocalDate() } }
+    var expandedDays by remember { mutableStateOf<Set<LocalDate>>(grouped.keys) }
+    LaunchedEffect(grouped.keys) {
+        expandedDays = grouped.keys
     }
-}
 
-@Composable
-private fun HistorySearchField(
-    query: String,
-    onQueryChange: (String) -> Unit,
-) {
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .background(JewelTheme.globalColors.panelBackground, RoundedCornerShape(8.dp))
-                .border(1.dp, JewelTheme.globalColors.borders.normal, RoundedCornerShape(8.dp))
-                .padding(horizontal = 12.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Icon(
-            key = AllIconsKeys.Actions.Find,
-            contentDescription = null,
-            modifier = Modifier.size(16.dp),
-            tint = JewelTheme.globalColors.text.info,
-        )
-        BasicTextField(
-            value = query,
-            onValueChange = onQueryChange,
-            singleLine = true,
-            textStyle = TextStyle(fontSize = 13.sp, color = JewelTheme.globalColors.text.normal),
-            cursorBrush = SolidColor(JewelTheme.globalColors.outlines.focused),
-            modifier = Modifier.weight(1f),
-            decorationBox = { innerTextField ->
+    fun dayLabel(day: LocalDate): String =
+        when (day) {
+            today -> todayLabel
+            today.minusDays(1) -> yesterdayLabel
+            else -> day.format(dateFormatter)
+        }
+
+    ListPageContainer {
+        PageHeader(
+            title = historyTitle,
+            actions = {
+                var showConfirm by remember { mutableStateOf(false) }
                 Box {
-                    if (query.isEmpty()) {
-                        Text(
-                            text = stringResource(Res.string.tab_search_placeholder),
-                            fontSize = 13.sp,
-                            color = JewelTheme.globalColors.text.info,
+                    IconButton(
+                        onClick = { showConfirm = true },
+                        modifier = Modifier.size(32.dp),
+                    ) {
+                        Icon(
+                            key = AllIconsKeys.General.Delete,
+                            contentDescription = stringResource(Res.string.history_clear_all),
+                            modifier = Modifier.size(18.dp),
                         )
                     }
-                    innerTextField()
+
+                    if (showConfirm) {
+                        Popup(
+                            onDismissRequest = { showConfirm = false },
+                            popupPositionProvider = StartBelowAnchorPositionProvider,
+                            properties = PopupProperties(focusable = true),
+                        ) {
+                            ConfirmPopup(
+                                title = stringResource(Res.string.history_clear_confirm_title),
+                                message = stringResource(Res.string.history_clear_confirm_message),
+                                confirmText = stringResource(Res.string.history_clear_confirm_yes),
+                                cancelText = stringResource(Res.string.settings_cancel),
+                                onConfirm = {
+                                    onClearAll()
+                                    showConfirm = false
+                                },
+                                onCancel = { showConfirm = false },
+                            )
+                        }
+                    }
                 }
             },
         )
-    }
-}
 
-@Composable
-private fun HistoryRow(
-    entry: VisitEntry,
-    zone: ZoneId,
-    onOpen: () -> Unit,
-    onDelete: () -> Unit,
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isHovered by interactionSource.collectIsHoveredAsState()
-    val accent = JewelTheme.globalColors.outlines.focused
-    val timeFormatter = remember { DateTimeFormatter.ofPattern("HH:mm") }
-
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .hoverable(interactionSource)
-                .background(if (isHovered) accent.copy(alpha = 0.06f) else Color.Transparent, RoundedCornerShape(6.dp))
-                .clickable(interactionSource = interactionSource, indication = null, onClick = onOpen)
-                .padding(horizontal = 10.dp, vertical = 7.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Text(
-            text =
-                Instant
-                    .ofEpochMilli(entry.visitedAt)
-                    .atZone(zone)
-                    .toLocalTime()
-                    .format(timeFormatter),
-            fontSize = 12.sp,
-            color = JewelTheme.globalColors.text.info,
+        PageSearchField(
+            query = query,
+            placeholder = Res.string.tab_search_placeholder,
+            onQueryChange = onQueryChange,
         )
-        if (entry.kind == VisitKind.BOOK) {
-            androidx.compose.foundation.Image(
-                painter = rememberVectorPainter(bookOpenTabs(JewelTheme.globalColors.text.normal)),
-                contentDescription = null,
-                modifier = Modifier.size(16.dp),
-                colorFilter = ColorFilter.tint(JewelTheme.globalColors.text.normal),
+
+        if (entries.isEmpty()) {
+            EmptyState(
+                iconKey = AllIconsKeys.Vcs.History,
+                message = stringResource(Res.string.history_empty),
             )
         } else {
-            Icon(
-                key = AllIconsKeys.Actions.Find,
-                contentDescription = null,
-                modifier = Modifier.size(16.dp),
-                tint = JewelTheme.globalColors.text.normal,
-            )
-        }
-        Text(
-            text = entry.title,
-            fontSize = 13.sp,
-            color = JewelTheme.globalColors.text.normal,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
-        Spacer(modifier = Modifier.size(4.dp))
-        Box(
-            modifier =
-                Modifier
-                    .size(20.dp)
-                    .background(if (isHovered) accent.copy(alpha = 0.10f) else Color.Transparent, CircleShape)
-                    .clickable(onClick = onDelete),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                key = AllIconsKeys.Actions.Close,
-                contentDescription = null,
-                modifier = Modifier.size(14.dp),
-                tint = if (isHovered) JewelTheme.globalColors.text.normal else Color.Transparent,
-            )
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                grouped.forEach { (day, dayEntries) ->
+                    val expanded = day in expandedDays
+
+                    item(key = "day-$day") {
+                        val label = remember(day) { dayLabel(day) }
+                        CardSurface(
+                            modifier = Modifier.padding(vertical = 2.dp),
+                        ) {
+                            Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                                SectionHeader(
+                                    title = label,
+                                    count = dayEntries.size,
+                                    expanded = expanded,
+                                    onToggleExpand = {
+                                        expandedDays =
+                                            if (expanded) {
+                                                expandedDays - day
+                                            } else {
+                                                expandedDays + day
+                                            }
+                                    },
+                                )
+                                if (expanded) {
+                                    dayEntries.forEachIndexed { index, entry ->
+                                        val time =
+                                            remember(entry.visitedAt) {
+                                                Instant
+                                                    .ofEpochMilli(entry.visitedAt)
+                                                    .atZone(zone)
+                                                    .toLocalTime()
+                                                    .format(timeFormatter)
+                                            }
+                                        ListRow(
+                                            title = entry.title,
+                                            onOpen = { onOpen(entry) },
+                                            onDelete = { onDelete(entry) },
+                                            leadingContent = {
+                                                Text(
+                                                    text = time,
+                                                    fontSize = 12.sp,
+                                                    color = JewelTheme.globalColors.text.info,
+                                                )
+                                            },
+                                            leadingIconVector =
+                                                if (entry.kind == VisitKind.BOOK) {
+                                                    bookOpenTabs(JewelTheme.globalColors.text.normal)
+                                                } else {
+                                                    null
+                                                },
+                                            leadingIconKey =
+                                                if (entry.kind == VisitKind.SEARCH) {
+                                                    AllIconsKeys.Actions.Find
+                                                } else {
+                                                    null
+                                                },
+                                            leadingTint = JewelTheme.globalColors.text.normal,
+                                            showDivider = index < dayEntries.lastIndex,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/di/AppGraph.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/di/AppGraph.kt
@@ -8,6 +8,7 @@ import io.github.kdroidfilter.seforimapp.core.MainAppState
 import io.github.kdroidfilter.seforimapp.core.annotations.HighlightStore
 import io.github.kdroidfilter.seforimapp.core.annotations.NoteStore
 import io.github.kdroidfilter.seforimapp.core.catalog.CatalogAccess
+import io.github.kdroidfilter.seforimapp.core.favorites.FavoritesStore
 import io.github.kdroidfilter.seforimapp.core.history.HistoryStore
 import io.github.kdroidfilter.seforimapp.core.selection.SelectionContext
 import io.github.kdroidfilter.seforimapp.core.settings.CategoryDisplaySettingsStore
@@ -37,6 +38,7 @@ abstract class AppGraph : ViewModelGraph {
     abstract val categoryDisplaySettingsStore: CategoryDisplaySettingsStore
     abstract val highlightStore: HighlightStore
     abstract val historyStore: HistoryStore
+    abstract val favoritesStore: FavoritesStore
     abstract val noteStore: NoteStore
     abstract val repository: SeforimRepository
     abstract val searchEngine: SearchEngine

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/di/modules/AppCoreBindings.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/di/modules/AppCoreBindings.kt
@@ -11,6 +11,7 @@ import io.github.kdroidfilter.seforimapp.core.MainAppState
 import io.github.kdroidfilter.seforimapp.core.annotations.HighlightStore
 import io.github.kdroidfilter.seforimapp.core.annotations.NoteStore
 import io.github.kdroidfilter.seforimapp.core.catalog.CatalogAccess
+import io.github.kdroidfilter.seforimapp.core.favorites.FavoritesStore
 import io.github.kdroidfilter.seforimapp.core.history.HistoryStore
 import io.github.kdroidfilter.seforimapp.core.selection.DefaultSelectionContext
 import io.github.kdroidfilter.seforimapp.core.selection.SelectionContext
@@ -91,6 +92,10 @@ object AppCoreBindings {
     @Provides
     @SingleIn(AppScope::class)
     fun provideHistoryStore(database: UserSettingsDb): HistoryStore = HistoryStore(database)
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideFavoritesStore(database: UserSettingsDb): FavoritesStore = FavoritesStore(database)
 
     @Provides
     @SingleIn(AppScope::class)

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/session/SessionManager.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/session/SessionManager.kt
@@ -245,6 +245,10 @@ object SessionManager {
                 is TabsDestination.History -> {
                     // No-op: the History screen localizes its own title.
                 }
+
+                is TabsDestination.Favorites -> {
+                    // No-op: the Favorites screen localizes its own title.
+                }
             }
         }
         return titles

--- a/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabTitleUpdateManager.kt
+++ b/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabTitleUpdateManager.kt
@@ -11,6 +11,7 @@ enum class TabType {
     BOOK,
     SEARCH,
     HISTORY,
+    FAVORITES,
 }
 
 /**

--- a/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsDestination.kt
+++ b/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsDestination.kt
@@ -36,4 +36,11 @@ sealed interface TabsDestination {
     data class History(
         override val tabId: String,
     ) : TabsDestination
+
+    /** Favorites page (the chrome://bookmarks equivalent). */
+    @Serializable
+    @Immutable
+    data class Favorites(
+        override val tabId: String,
+    ) : TabsDestination
 }

--- a/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsViewModel.kt
+++ b/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsViewModel.kt
@@ -195,6 +195,7 @@ class TabsViewModel(
                 is TabsDestination.Search -> TabsDestination.Search(destination.searchQuery, destination.tabId)
                 is TabsDestination.BookContent -> TabsDestination.BookContent(destination.bookId, destination.tabId, destination.lineId)
                 is TabsDestination.History -> TabsDestination.History(destination.tabId)
+                is TabsDestination.Favorites -> TabsDestination.Favorites(destination.tabId)
             }
 
         val newTab =
@@ -280,6 +281,7 @@ class TabsViewModel(
                             lineId = destination.lineId,
                         )
                     is TabsDestination.History -> TabsDestination.History(tabId = tab.destination.tabId)
+                    is TabsDestination.Favorites -> TabsDestination.Favorites(tabId = tab.destination.tabId)
                 }
 
             val updated =
@@ -322,6 +324,7 @@ class TabsViewModel(
                             lineId = destination.lineId,
                         )
                     is TabsDestination.History -> TabsDestination.History(tabId = newTabId)
+                    is TabsDestination.Favorites -> TabsDestination.Favorites(tabId = newTabId)
                 }
 
             val updated =
@@ -432,6 +435,7 @@ class TabsViewModel(
             is TabsDestination.Search -> TabType.SEARCH
             is TabsDestination.BookContent -> if (destination.bookId > 0) TabType.BOOK else TabType.SEARCH
             is TabsDestination.History -> TabType.HISTORY
+            is TabsDestination.Favorites -> TabType.FAVORITES
         }
 
     private fun getTabTitle(destination: TabsDestination): String =
@@ -439,8 +443,9 @@ class TabsViewModel(
             is TabsDestination.Home -> ""
             is TabsDestination.Search -> destination.searchQuery
             is TabsDestination.BookContent -> if (destination.bookId > 0) "${destination.bookId}" else ""
-            // Localized by the History screen itself via TabTitleUpdateManager
+            // Localized by the History/Favorites screens themselves via TabTitleUpdateManager
             is TabsDestination.History -> ""
+            is TabsDestination.Favorites -> ""
         }
 
     private fun updateTabTitle(


### PR DESCRIPTION
## Summary

- **Favorites store**: new SQLDelight tables (`favorite` + `favorite_folder`) behind `FavoritesStore`, with flat user-created folders and revision-flow reactivity (same pattern as `HistoryStore`).
- **Favorites page**: new `TabsDestination.Favorites` tab with search, collapsible folder cards, and right-click move-to-folder context menu.
- **Breadcrumb actions**: copy-deep-link button and star/unstar button with a folder-picking popup on the book content breadcrumb bar.
- **Native macOS Favorites menu**: search field, "show all favorites", root favorites and folder submenus.
- **Keyboard shortcut**: Cmd+Alt+B (macOS) / Ctrl+Shift+O (others) opens or focuses the Favorites tab.
- **Shared list-page components** (`ListPageComponents.kt`): the History page is refactored on top of them and gains a confirmation popup before clearing all history.
- Bumps SeforimLibrary (exposes `isBaseBook` on `LineHit`).

Replaces #519, which was mistakenly merged into `master` and has been rolled back.

## Test plan

- `./gradlew :SeforimApp:compileKotlinJvm` and `:SeforimApp:ktlintCheck` pass
- Manual: star/unstar from breadcrumb, file into folders, open favorites from tab page and native menu, keyboard shortcut, history clear confirmation